### PR TITLE
Add cache layer for `cargo-binutils` installation

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -31,8 +31,9 @@ jobs:
           override: true
           components: llvm-tools
 
-      - name: Install cargo-binutils
-        run: cargo install cargo-binutils
+      - uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-binutils
 
       - name: Build kernel
         run: make build LOG=TRACE
@@ -57,8 +58,9 @@ jobs:
           override: true
           components: llvm-tools
 
-      - name: Install cargo-binutils
-        run: cargo install cargo-binutils
+      - uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-binutils
 
       - name: Build kernel
         run: make build LOG=TRACE


### PR DESCRIPTION
this should be able to speed up workflows that involves building kernel