### PR TITLE
Escape from `actions-rs/toolchain`

### DIFF
--- a/.github/workflows/crates-fmt.yml
+++ b/.github/workflows/crates-fmt.yml
@@ -25,12 +25,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          override: true
-          components: clippy
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+          rustup component add clippy
 
       - name: Run clippy
         run: cargo clippy -- -D warnings
@@ -47,12 +48,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          override: true
-          components: rustfmt
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+          rustup component add rustfmt
 
       - name: Check formatting
         run: cargo fmt -- --check

--- a/.github/workflows/crates-tests.yml
+++ b/.github/workflows/crates-tests.yml
@@ -25,11 +25,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          override: true
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+
 
       - name: Run tests
         run: cargo test --all

--- a/.github/workflows/kernel-fmt.yml
+++ b/.github/workflows/kernel-fmt.yml
@@ -25,13 +25,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          target: riscv64gc-unknown-none-elf
-          override: true
-          components: clippy
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+          rustup target add riscv64gc-unknown-none-elf
+          rustup component add clippy
 
       - name: Run clippy
         run: cargo clippy -- -D warnings
@@ -48,13 +49,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          target: riscv64gc-unknown-none-elf
-          override: true
-          components: rustfmt
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+          rustup target add riscv64gc-unknown-none-elf
+          rustup component add rustfmt
+
 
       - name: Check formatting
         run: cargo fmt -- --check

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -23,13 +23,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          target: riscv64gc-unknown-none-elf
-          override: true
-          components: llvm-tools
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+          rustup target add riscv64gc-unknown-none-elf
+          rustup component add llvm-tools
 
       - name: Install cargo-binutils
         run: cargo install cargo-binutils
@@ -49,13 +50,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          target: riscv64gc-unknown-none-elf
-          override: true
-          components: llvm-tools
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+          rustup target add riscv64gc-unknown-none-elf
+          rustup component add llvm-tools
 
       - name: Install cargo-binutils
         run: cargo install cargo-binutils

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -18,12 +18,13 @@ jobs:
         #   fetch-depth: 0
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-03
-          target: riscv64gc-unknown-none-elf
-          override: true
+        env: 
+            TOOLCHAIN_VERSION: nightly-2024-02-03
+        run: |
+          rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
+          rustup default $TOOLCHAIN_VERSION
+          rustup override set $TOOLCHAIN_VERSION
+          rustup target add riscv64gc-unknown-none-elf
 
       - name: Get current branch name
         id: vars


### PR DESCRIPTION
This pull request updates the Rust toolchain installation process across several GitHub workflow files. The changes replace the use of the `actions-rs/toolchain` GitHub Action with direct `rustup` commands to install and configure the toolchain. This ensures more control and flexibility over the toolchain setup.

Toolchain installation updates:

* [`.github/workflows/crates-fmt.yml`](diffhunk://#diff-4fc7f5681e52126fdfd00dae125afc532523caf7d8ce8f455ed65e7b5968f863L28-R34): Replaced `actions-rs/toolchain` with `rustup` commands for installing and configuring the Rust toolchain, including adding `clippy` and `rustfmt` components. [[1]](diffhunk://#diff-4fc7f5681e52126fdfd00dae125afc532523caf7d8ce8f455ed65e7b5968f863L28-R34) [[2]](diffhunk://#diff-4fc7f5681e52126fdfd00dae125afc532523caf7d8ce8f455ed65e7b5968f863L50-R57)
* [`.github/workflows/crates-tests.yml`](diffhunk://#diff-ea3e978625e54ea66fedf5bfd0898490a59f6ad6c718fb240ae72c39fb9cbe12L28-R34): Updated the toolchain installation to use `rustup` commands instead of `actions-rs/toolchain`.
* [`.github/workflows/kernel-fmt.yml`](diffhunk://#diff-122a37bdc748e46c71ede2f1c7923a936ec2715507b0a4a1f40213db5b078ec5L28-R35): Modified the workflow to use `rustup` for installing the toolchain and adding the `riscv64gc-unknown-none-elf` target and `clippy` and `rustfmt` components. [[1]](diffhunk://#diff-122a37bdc748e46c71ede2f1c7923a936ec2715507b0a4a1f40213db5b078ec5L28-R35) [[2]](diffhunk://#diff-122a37bdc748e46c71ede2f1c7923a936ec2715507b0a4a1f40213db5b078ec5L51-R60)
* [`.github/workflows/kernel.yml`](diffhunk://#diff-223ebb0cca9aab842353946bc5cbefa96d828c04b090543e7cd14d237925ae90L26-R33): Changed the toolchain setup to use `rustup` commands, including adding the `riscv64gc-unknown-none-elf` target and `llvm-tools` component. [[1]](diffhunk://#diff-223ebb0cca9aab842353946bc5cbefa96d828c04b090543e7cd14d237925ae90L26-R33) [[2]](diffhunk://#diff-223ebb0cca9aab842353946bc5cbefa96d828c04b090543e7cd14d237925ae90L52-R60)
* [`.github/workflows/vendor.yml`](diffhunk://#diff-9c93e82f4489fa464e962839fc18bb3849015882259535094345145238f90610L21-R27): Updated the Rust setup to use `rustup` for installing the toolchain and adding the `riscv64gc-unknown-none-elf` target.