### PR TITLE
fix: update branch name retrieval method in GitHub Actions workflow

### DIFF
--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get current branch name
         id: vars
-        run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+        run: echo "BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/vendor.yml` file. The change updates the method for retrieving the current branch name in the GitHub Actions workflow.

* [`.github/workflows/vendor.yml`](diffhunk://#diff-9c93e82f4489fa464e962839fc18bb3849015882259535094345145238f90610L31-R31): Modified the command to get the current branch name from using `${GITHUB_REF##*/}` to `$(git rev-parse --abbrev-ref HEAD)`.

This fixes vendor branches of those containing `/` not being named properly. 