### PR TITLE
Update to support 2025 preliminary contest

### DIFF
--- a/test_preliminary/test_script.sh
+++ b/test_preliminary/test_script.sh
@@ -1,0 +1,111 @@
+#!/bin/busybox
+
+/mnt/basic/uname
+/mnt/basic/write
+/mnt/basic/times
+/mnt/basic/brk
+/mnt/basic/gettimeofday
+/mnt/basic/getpid
+/mnt/basic/getppid
+/mnt/basic/getcwd
+/mnt/basic/sleep
+/mnt/basic/fork
+/mnt/basic/clone
+/mnt/basic/yield
+/mnt/basic/exit
+/mnt/basic/wait
+/mnt/basic/waitpid
+/mnt/basic/execve
+/mnt/basic/pipe
+/mnt/basic/dup
+/mnt/basic/dup2
+/mnt/basic/openat
+/mnt/basic/open
+/mnt/basic/close
+/mnt/basic/read
+/mnt/basic/mount
+/mnt/basic/umount
+/mnt/basic/mkdir_
+/mnt/basic/chdir
+/mnt/basic/fstat
+/mnt/basic/getdents
+/mnt/basic/unlink
+/mnt/basic/mmap
+/mnt/basic/munmap
+
+busybox echo "run libctest_testcode.sh"
+./libctest_testcode.sh
+busybox echo "run lua_testcode.sh"
+./lua_testcode.sh
+
+test_busybox_command() {
+    local line="$1"
+    eval "./busybox $line"
+    local RTN=$?
+    if [[ $RTN -ne 0 && $line != "false" ]]; then
+        echo "\ntestcase busybox $line fail"
+        # echo "return: $RTN, cmd: $line" >> $RST
+    else
+        echo "\ntestcase busybox $line success"
+    fi
+}
+
+test_busybox_command "echo \"#### independent command test\""
+test_busybox_command "ash -c exit"
+test_busybox_command "sh -c exit"
+test_busybox_command "basename /aaa/bbb"
+test_busybox_command "cal"
+test_busybox_command "clear"
+test_busybox_command "date"
+test_busybox_command "df"
+test_busybox_command "dirname /aaa/bbb"
+test_busybox_command "dmesg"
+test_busybox_command "du"
+test_busybox_command "expr 1 + 1"
+test_busybox_command "false"
+test_busybox_command "true"
+test_busybox_command "which ls"
+test_busybox_command "uname"
+test_busybox_command "uptime"
+test_busybox_command "printf \"abc\n\""
+test_busybox_command "ps"
+test_busybox_command "pwd"
+test_busybox_command "free"
+test_busybox_command "hwclock"
+test_busybox_command "kill 10"
+test_busybox_command "ls"
+test_busybox_command "sleep 1"
+
+test_busybox_command "echo \"#### file opration test\""
+test_busybox_command "touch test.txt"
+test_busybox_command "echo \"hello world\" > test.txt"
+test_busybox_command "cat test.txt"
+test_busybox_command "cut -c 3 test.txt"
+test_busybox_command "od test.txt"
+test_busybox_command "head test.txt"
+test_busybox_command "tail test.txt"
+test_busybox_command "hexdump -C test.txt"
+test_busybox_command "md5sum test.txt"
+test_busybox_command "echo \"ccccccc\" >> test.txt"
+test_busybox_command "echo \"bbbbbbb\" >> test.txt"
+test_busybox_command "echo \"aaaaaaa\" >> test.txt"
+test_busybox_command "echo \"2222222\" >> test.txt"
+test_busybox_command "echo \"1111111\" >> test.txt"
+test_busybox_command "echo \"bbbbbbb\" >> test.txt"
+test_busybox_command "sort test.txt | ./busybox uniq"
+test_busybox_command "stat test.txt"
+test_busybox_command "strings test.txt"
+test_busybox_command "wc test.txt"
+test_busybox_command "[ -f test.txt ]"
+test_busybox_command "more test.txt"
+test_busybox_command "rm test.txt"
+test_busybox_command "mkdir test_dir"
+test_busybox_command "mv test_dir test"
+test_busybox_command "rmdir test"
+test_busybox_command "grep hello busybox_cmd.txt"
+test_busybox_command "cp busybox_cmd.txt busybox_cmd.bak"
+test_busybox_command "rm busybox_cmd.bak"
+test_busybox_command "find -name \"busybox_cmd.txt\""
+
+busybox echo "run iozone_testcode.sh"
+./iozone_testcode.sh


### PR DESCRIPTION
Requires:

- [x] - Prepare test scripts for 2025 preliminary contest
- [X] - Update main logic to run test scritps
- [x] - Prepare to link essential files to root
- [ ] - Update test suits sdcard image
- [ ] - Update CI workflows
- [x] - Update grading scripts
- [x] - Support `lseek` and `truncate` syscalls
- [ ] - Inherit shared memory mappings for forked processes
- [ ] - Support iozone
- [x] - #23 
- [ ] - Merge master
- [x] - Update Qemu to 9.2.1 in CI, requires a lot of dependencies 

Test suit sdcard image: https://github.com/neuq-rcore/testsuits-for-oskernel/releases/tag/pre-2025-rv
Test suit source code: https://github.com/oscomp/testsuits-for-oskernel/tree/pre-2025
mirror: https://github.com/neuq-rcore/testsuits-for-oskernel/tree/pre-2025

