### PR TITLE
Secure User/Kernel Isolation via Split Page Tables with Trampoline Support

### DIFF
--- a/crates/platform-abstractions/src/loongarch64/context.rs
+++ b/crates/platform-abstractions/src/loongarch64/context.rs
@@ -9,10 +9,23 @@ pub(crate) struct KernelThreadContext {
     // Which is usually in `return_to_user` funciton
     pub kra: usize,
     pub ksp: usize, // kernel stack pointer
+    pub pt: usize,  // kernel page table
 }
 
 static mut THREAD_CONTEXT_POOL: [KernelThreadContext; PROCESSOR_COUNT] =
     unsafe { core::mem::zeroed() };
+
+#[expect(dead_code)]
+pub(crate) fn set_kernel_page_table(pt: usize) {
+    // page table must be aligned to 4K
+    debug_assert!(pt % 4096 == 0);
+
+    let cpu = platform_specific::current_processor_index();
+
+    unsafe {
+        THREAD_CONTEXT_POOL[cpu].pt = pt;
+    }
+}
 
 // # Safety
 // This writes to $tp register

--- a/crates/platform-abstractions/src/riscv64/context.rs
+++ b/crates/platform-abstractions/src/riscv64/context.rs
@@ -13,6 +13,7 @@ struct CoroutineSavedContext {
 #[repr(C)]
 #[derive(Default, Debug, Clone, Copy)]
 struct KernelThreadContext {
+    pub pt: usize, // kernel page table
     pub hartid: usize,
     pub ctx: CoroutineSavedContext,
 }
@@ -20,16 +21,29 @@ struct KernelThreadContext {
 static mut THREAD_CONTEXT_POOL: [KernelThreadContext; PROCESSOR_COUNT] =
     unsafe { core::mem::zeroed() };
 
+#[expect(dead_code)]
+pub(crate) fn set_kernel_page_table(pt: usize) {
+    // page table must be aligned to 4K
+    debug_assert!(pt % 4096 == 0);
+
+    let cpu = platform_specific::current_processor_index();
+
+    unsafe {
+        THREAD_CONTEXT_POOL[cpu].pt = pt;
+    }
+}
+
 // # Safety
 // Can only be called once for each thread.
 pub unsafe fn init_thread_info() {
     let hartid = platform_specific::tp();
-    let p_ctx = unsafe { &raw mut THREAD_CONTEXT_POOL[hartid] }.cast::<usize>();
+    let p_ctx = unsafe { &raw mut THREAD_CONTEXT_POOL[hartid] };
 
-    p_ctx.write_volatile(hartid);
+    // initialize hart id in the thread context
+    p_ctx.cast::<usize>().add(1).write_volatile(hartid);
 
     // Coroutine saved context
-    let p_ctx = p_ctx.add(1) as usize;
+    let p_ctx = p_ctx.add(2) as usize;
 
     ::core::arch::asm!("mv tp, {}", in(reg) p_ctx);
 }


### PR DESCRIPTION
see #42 