### PR TITLE
Build: Bump Rust toolchain to version `nightly-2025-02-01`

### DIFF
--- a/.github/workflows/crates-fmt.yml
+++ b/.github/workflows/crates-fmt.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION

--- a/.github/workflows/crates-tests.yml
+++ b/.github/workflows/crates-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION

--- a/.github/workflows/final.yml
+++ b/.github/workflows/final.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION

--- a/.github/workflows/kernel-fmt.yml
+++ b/.github/workflows/kernel-fmt.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION

--- a/.github/workflows/preliminary.yml
+++ b/.github/workflows/preliminary.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Rust toolchain
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Set up Rust
         env: 
-            TOOLCHAIN_VERSION: nightly-2025-01-18
+            TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install $TOOLCHAIN_VERSION --profile minimal
           rustup default $TOOLCHAIN_VERSION

--- a/crates/filesystem-abstractions/src/tree.rs
+++ b/crates/filesystem-abstractions/src/tree.rs
@@ -687,7 +687,7 @@ impl Drop for DirectoryTreeNode {
 }
 
 impl DirectoryTreeNode {
-    pub fn metadata<'a>(self: &'a Arc<DirectoryTreeNode>) -> InodeMetadata<'a> {
+    pub fn metadata(self: &Arc<DirectoryTreeNode>) -> InodeMetadata {
         let inner = self.inner.lock();
         let filename = self.name();
 

--- a/crates/tasks/src/uesr_task.rs
+++ b/crates/tasks/src/uesr_task.rs
@@ -143,7 +143,7 @@ impl TaskControlBlock {
         &mut *self.trap_context.get()
     }
 
-    pub fn to_syscall_context<'a>(self: &'a Arc<Self>) -> SyscallContext<'a> {
+    pub fn to_syscall_context(self: &Arc<Self>) -> SyscallContext {
         SyscallContext::new(unsafe { self.mut_trap_ctx() }, self.clone())
     }
 }

--- a/docs/bakaos-simple-kernel/rust-toolchain.toml
+++ b/docs/bakaos-simple-kernel/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2025-01-18"
+channel = "nightly-2025-02-01"
 targets = ["riscv64gc-unknown-none-elf", "loongarch64-unknown-none"]
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2025-01-18"
+channel = "nightly-2025-02-01"
 targets = ["riscv64gc-unknown-none-elf", "loongarch64-unknown-none"]
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]


### PR DESCRIPTION
- Update Rust toolchain version in multiple workflow files and rust-toolchain.toml
- Change TOOLCHAIN_VERSION from nightly-2025-01-18 to nightly-2025-02-01
- Update rust-toolchain.toml files in project root and bakaos-simple-kernel directory