### PR TITLE
Feat: Implement `/proc/interrputs` node

### DIFF
--- a/crates/filesystem-abstractions/src/inode.rs
+++ b/crates/filesystem-abstractions/src/inode.rs
@@ -67,6 +67,18 @@ pub trait IInode: DowncastSync + Send + Sync {
     fn resize(&self, _new_size: u64) -> FileSystemResult<u64> {
         Err(FileSystemError::NotAFile)
     }
+
+    fn removing(&self) -> FileSystemResult<()> {
+        Ok(())
+    }
+
+    fn rename(&self, _old_name: &str, _new_name: &str) -> FileSystemResult<()> {
+        Err(FileSystemError::Unimplemented)
+    }
+
+    fn renaming(&self, _new_name: &str) -> FileSystemResult<()> {
+        Ok(())
+    }
 }
 
 impl_downcast!(sync IInode);

--- a/crates/filesystem-abstractions/src/lib.rs
+++ b/crates/filesystem-abstractions/src/lib.rs
@@ -51,6 +51,8 @@ pub enum FileSystemError {
     NotADirectory,
     NotALink,
     LinkTooDepth,
+    NotPermitted,
+    ReadOnly,
 }
 
 impl FileSystemError {
@@ -69,6 +71,8 @@ impl FileSystemError {
             FileSystemError::NotADirectory => ErrNo::NotADirectory,
             FileSystemError::NotALink => ErrNo::InvalidArgument,
             FileSystemError::LinkTooDepth => ErrNo::TooManyLevelsOfSymbolicLinks,
+            FileSystemError::NotPermitted => ErrNo::OperationNotPermitted,
+            FileSystemError::ReadOnly => ErrNo::ReadOnlyFileSystem,
             _ => ErrNo::Success,
         }
     }

--- a/crates/filesystem-abstractions/src/tree.rs
+++ b/crates/filesystem-abstractions/src/tree.rs
@@ -1591,7 +1591,7 @@ mod tests {
         let child = DirectoryTreeNode::from_empty(Some(Arc::clone(&parent)), "child".to_string());
 
         parent.mount_as(Arc::clone(&child), Some("child")).unwrap();
-        let (closed, unmounted) = parent.close("child");
+        let (closed, unmounted) = parent.close("child").unwrap();
         assert!(closed || unmounted);
         assert!(!parent.inner.lock().is_mounted("child"));
     }

--- a/crates/filesystem-abstractions/src/tree.rs
+++ b/crates/filesystem-abstractions/src/tree.rs
@@ -1054,17 +1054,17 @@ impl DirectoryTreeNode {
         checked_rename!(opened, false, false);
         checked_rename!(children_cache, false, true);
 
-        match &inner.meta {
-            DirectoryTreeNodeMetadata::Inode { inode } => inode.rename(old_name, new_name),
+        match inner.meta.as_inode() {
+            Some(inode) => inode.rename(old_name, new_name),
             _ => Err(FileSystemError::NotFound),
         }
     }
 
     fn renaming(self: &Arc<DirectoryTreeNode>, new_name: &str) -> FileSystemResult<()> {
-        let mut inner = self.inner.lock();
+        let inner = self.inner.lock();
 
-        match &mut inner.meta {
-            DirectoryTreeNodeMetadata::Inode { inode } => inode.renaming(new_name),
+        match inner.meta.as_inode() {
+            Some(inode) => inode.renaming(new_name),
             _ => Ok(()),
         }
     }
@@ -1072,8 +1072,8 @@ impl DirectoryTreeNode {
     fn removing(self: &Arc<DirectoryTreeNode>) -> FileSystemResult<()> {
         let inner = self.inner.lock();
 
-        match &inner.meta {
-            DirectoryTreeNodeMetadata::Inode { inode } => inode.removing(),
+        match inner.meta.as_inode() {
+            Some(inode) => inode.removing(),
             _ => Ok(()),
         }
     }

--- a/crates/filesystem-abstractions/src/tree.rs
+++ b/crates/filesystem-abstractions/src/tree.rs
@@ -485,16 +485,27 @@ impl DirectoryTreeNode {
         unsafe { &self.inner.data_ptr().as_ref().unwrap().name }
     }
 
-    pub fn close(&self, name: &str) -> (bool, bool) {
+    pub fn close(&self, name: &str) -> FileSystemResult<(bool, bool)> {
         let mut inner = self.inner.lock();
 
         let closed = inner.opened.remove(name);
-        let unmounted = inner.mounted.remove(name);
+        let mut unmounted = inner.mounted.remove_entry(name);
+
+        if let Some((name, unmounted_node)) = unmounted {
+            if let Err(e) = unmounted_node.removing() {
+                inner.mounted.insert(name, unmounted_node);
+
+                return Err(e);
+            }
+
+            unmounted = Some((name, unmounted_node));
+        }
+
         inner.children_cache.remove(name);
 
         drop(inner); // prevent deadlock in recursive close
 
-        (closed.is_some(), unmounted.is_some())
+        Ok((closed.is_some(), unmounted.is_some()))
     }
 
     pub fn open(
@@ -681,7 +692,9 @@ impl DirectoryTreeNode {
 impl Drop for DirectoryTreeNode {
     fn drop(&mut self) {
         if let Some(ref parent) = self.parent {
-            parent.close(self.name());
+            if let Err(e) = parent.close(self.name()) {
+                log::warn!("Failed to close directory node: {}, {:?}", self.name(), e);
+            }
         }
     }
 }
@@ -759,9 +772,10 @@ impl DirectoryTreeNode {
     }
 
     pub fn rmdir(self: &Arc<DirectoryTreeNode>, name: &str) -> FileSystemResult<()> {
-        // FIXME: Do we have to check if it's a directory?
-        if self.close(name).1 {
-            return Ok(());
+        match self.close(name) {
+            Ok((closed, unmounted)) if closed || unmounted => return Ok(()),
+            Err(e) => return Err(e),
+            _ => (),
         }
 
         match self.inner.lock().meta.as_inode() {
@@ -771,8 +785,10 @@ impl DirectoryTreeNode {
     }
 
     pub fn remove(self: &Arc<DirectoryTreeNode>, name: &str) -> FileSystemResult<()> {
-        if self.close(name).1 {
-            return Ok(());
+        match self.close(name) {
+            Ok((closed, unmounted)) if closed || unmounted => return Ok(()),
+            Err(e) => return Err(e),
+            _ => (),
         }
 
         match self.inner.lock().meta.as_inode() {
@@ -999,6 +1015,66 @@ impl DirectoryTreeNode {
         match inner.meta.as_inode() {
             Some(inode) => inode.resize(new_size),
             None => Err(FileSystemError::NotAFile),
+        }
+    }
+
+    pub fn rename(
+        self: &Arc<DirectoryTreeNode>,
+        old_name: &str,
+        new_name: &str,
+    ) -> FileSystemResult<()> {
+        let mut inner = self.inner.lock();
+
+        macro_rules! do_check {
+            ($field:ident, $old_name:ident, $node:ident, true) => {
+                if let Err(err) = $node.renaming(new_name) {
+                    inner.$field.insert($old_name, $node);
+
+                    return Err(err);
+                }
+            };
+            ($field:ident, $old_name:ident, $node:ident, false) => {};
+        }
+
+        macro_rules! checked_rename {
+            ($field:ident, $early_return:tt, $do_check:tt) => {
+                if let Some((_old_name, node)) = inner.$field.remove_entry(old_name) {
+                    do_check!($field, _old_name, node, $do_check);
+
+                    inner.$field.insert(new_name.to_string(), node);
+
+                    if $early_return {
+                        return Ok(());
+                    }
+                }
+            };
+        }
+
+        checked_rename!(mounted, true, true); // early return | do renaming check
+        checked_rename!(opened, false, false);
+        checked_rename!(children_cache, false, true);
+
+        match &inner.meta {
+            DirectoryTreeNodeMetadata::Inode { inode } => inode.rename(old_name, new_name),
+            _ => Err(FileSystemError::NotFound),
+        }
+    }
+
+    fn renaming(self: &Arc<DirectoryTreeNode>, new_name: &str) -> FileSystemResult<()> {
+        let mut inner = self.inner.lock();
+
+        match &mut inner.meta {
+            DirectoryTreeNodeMetadata::Inode { inode } => inode.renaming(new_name),
+            _ => Ok(()),
+        }
+    }
+
+    fn removing(self: &Arc<DirectoryTreeNode>) -> FileSystemResult<()> {
+        let inner = self.inner.lock();
+
+        match &inner.meta {
+            DirectoryTreeNodeMetadata::Inode { inode } => inode.removing(),
+            _ => Ok(()),
         }
     }
 }

--- a/crates/platform-specific/src/loongarch64/syscall_ids.rs
+++ b/crates/platform-specific/src/loongarch64/syscall_ids.rs
@@ -53,6 +53,7 @@ pub const SYSCALL_ID_EXECVE: usize = 221;
 pub const SYSCALL_ID_MMAP: usize = 222;
 pub const SYSCALL_ID_WAIT4: usize = 260;
 pub const SYSCALL_ID_PRLIMIT64: usize = 261;
+pub const SYSCALL_ID_RENAMEAT2: usize = 276;
 pub const SYSCALL_ID_GETRANDOM: usize = 278;
 pub const SYSCALL_ID_STATX: usize = 291;
 pub const SYSCALL_ID_CLOCK_GETTIME: usize = 113;

--- a/crates/platform-specific/src/riscv64/syscall_ids.rs
+++ b/crates/platform-specific/src/riscv64/syscall_ids.rs
@@ -55,6 +55,7 @@ pub const SYSCALL_ID_EXECVE: usize = 221;
 pub const SYSCALL_ID_MMAP: usize = 222;
 pub const SYSCALL_ID_WAIT4: usize = 260;
 pub const SYSCALL_ID_PRLIMIT64: usize = 261;
+pub const SYSCALL_ID_RENAMEAT2: usize = 276;
 pub const SYSCALL_ID_GETRANDOM: usize = 278;
 pub const SYSCALL_ID_STATX: usize = 291;
 pub const SYSCALL_ID_CLOCK_GETTIME: usize = 113;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -31,6 +31,8 @@ use platform_specific::legacy_println;
 use scheduling::ProcDeviceInode;
 use tasks::ProcessControlBlock;
 
+use crate::trap::ProcInterrputsInode;
+
 extern crate alloc;
 
 // Rust compiler leaves out `_start` if not explicitly used in the exact project to be compiled
@@ -284,6 +286,8 @@ unsafe extern "C" fn __kernel_init() {
 
     filesystem_abstractions::initialize();
     ProcDeviceInode::setup();
+
+    global_mount_inode(&ProcInterrputsInode::new(), "/proc/interrupts", None).unwrap();
 
     let sda = machine.create_block_device_at(0);
     filesystem_abstractions::global_mount_inode(&(sda as Arc<dyn IInode>), "/dev/sda", None)

--- a/kernel/src/syscalls/file.rs
+++ b/kernel/src/syscalls/file.rs
@@ -1222,3 +1222,85 @@ impl ISyncSyscallHandler for StatxSyscall {
         "sys_statx"
     }
 }
+
+pub struct RenameAt2Syscall;
+
+impl ISyncSyscallHandler for RenameAt2Syscall {
+    fn handle(&self, ctx: &mut SyscallContext) -> SyscallResult {
+        const PATH_MAX_LEN: usize = 256;
+        const PAGE_FLAGS: GenericMappingFlags =
+            GenericMappingFlags::User.union(GenericMappingFlags::Readable);
+
+        let old_dirfd = ctx.arg0::<usize>();
+        let old_path = ctx.arg1::<*const u8>();
+        let new_dirfd = ctx.arg2::<usize>();
+        let new_path = ctx.arg3::<*const u8>();
+
+        macro_rules! get_fd_from_inode {
+            ($pcb:ident, $fd:ident) => {
+                $pcb.fd_table
+                    .get($fd)
+                    .ok_or(ErrNo::BadFileDescriptor)?
+                    .access_ref()
+                    .inode()
+            };
+        }
+
+        let pcb = ctx.pcb.lock();
+
+        let old_dirfd = get_fd_from_inode!(pcb, old_dirfd);
+        let new_dirfd = get_fd_from_inode!(pcb, new_dirfd);
+
+        match (
+            ctx.borrow_page_table()
+                .guard_cstr(old_path, PATH_MAX_LEN)
+                .must_have(PAGE_FLAGS),
+            ctx.borrow_page_table()
+                .guard_cstr(new_path, PATH_MAX_LEN)
+                .must_have(PAGE_FLAGS),
+        ) {
+            (Some(old_path), Some(new_path)) => {
+                let old_path = unsafe { core::str::from_utf8_unchecked(&old_path) };
+                let new_path = unsafe { core::str::from_utf8_unchecked(&new_path) };
+
+                let (old_parent, old_name) = (
+                    path::get_directory_name(old_path).unwrap_or(path::DOT_STR),
+                    path::get_filename(old_path),
+                );
+
+                let old_parent = global_open(old_parent, old_dirfd.as_ref())
+                    .map_err(|_| ErrNo::NoSuchFileOrDirectory)?;
+
+                let (new_parent, new_name) = (
+                    path::get_directory_name(new_path).unwrap_or(path::DOT_STR),
+                    path::get_filename(new_path),
+                );
+
+                let new_parent = global_open(new_parent, new_dirfd.as_ref())
+                    .map_err(|_| ErrNo::NoSuchFileOrDirectory)?;
+
+                if Arc::ptr_eq(&old_parent, &new_parent) {
+                    return old_parent
+                        .rename(old_name, new_name)
+                        .map(|_| 0)
+                        .map_err(|e| e.to_errno());
+                } else {
+                    // FIXME: we have to move the node to the new parent
+                    #[cfg(debug_assertions)]
+                    unimplemented!();
+
+                    #[cfg(not(debug_assertions))]
+                    return Ok(0);
+                }
+
+                #[allow(unreachable_code)]
+                SyscallError::Success
+            }
+            _ => SyscallError::BadAddress,
+        }
+    }
+
+    fn name(&self) -> &str {
+        "sys_renameat2"
+    }
+}

--- a/kernel/src/syscalls/mod.rs
+++ b/kernel/src/syscalls/mod.rs
@@ -25,6 +25,8 @@ use task_async::{sys_nanosleep_async, sys_sched_yield_async, sys_wait4_async};
 use platform_specific::{syscall_ids::*, ISyscallContext};
 use tasks::SyscallContext;
 
+use crate::syscalls::file::RenameAt2Syscall;
+
 mod file;
 mod file_async;
 mod futex_async;
@@ -105,6 +107,7 @@ impl SyscallDispatcher {
             SYSCALL_ID_SHMAT => Some(&SharedMemoryAttachSyscall),
             SYSCALL_ID_SOCKET => Some(&SocketSyscall),
             SYSCALL_ID_STATX => Some(&StatxSyscall),
+            SYSCALL_ID_RENAMEAT2 => Some(&RenameAt2Syscall),
             _ => None,
         }
     }

--- a/kernel/src/trap.rs
+++ b/kernel/src/trap.rs
@@ -1,15 +1,23 @@
-use alloc::sync::Arc;
+use alloc::{format, string::String, sync::Arc};
+use filesystem_abstractions::{FileSystemError, FileSystemResult, IInode, InodeMetadata};
 use log::{trace, warn};
 use platform_abstractions::UserInterrupt;
 use platform_specific::{ISyscallContext, ISyscallContextMut};
 use tasks::{TaskControlBlock, TaskStatus};
 
-use crate::syscalls::{ISyscallResult, SyscallDispatcher};
+use crate::{
+    kernel::kernel_metadata,
+    syscalls::{ISyscallResult, SyscallDispatcher},
+};
 
 pub async fn user_trap_handler_async(tcb: &Arc<TaskControlBlock>, return_reason: UserInterrupt) {
+    let kernel_stat = kernel_metadata().stat();
+
     match return_reason {
         UserInterrupt::Unknown(payload) => panic!("Unknown user trap occurred: {:?}", payload),
         UserInterrupt::Syscall => {
+            kernel_stat.on_syscall();
+
             let mut ctx = tcb.to_syscall_context();
 
             ctx.move_to_next_instruction();
@@ -50,5 +58,75 @@ pub async fn user_trap_handler_async(tcb: &Arc<TaskControlBlock>, return_reason:
 
             *tcb.task_status.lock() = TaskStatus::Exited;
         }
+    }
+}
+
+pub(crate) struct ProcInterrputsInode;
+
+impl ProcInterrputsInode {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new() -> Arc<dyn IInode> {
+        Arc::new(ProcInterrputsInode)
+    }
+
+    fn generate_content(&self) -> String {
+        let mut content = String::new();
+        let mut vector_id = 0;
+
+        macro_rules! add_field {
+            ($count:expr) => {
+                content.push_str(&format!("{}: {}\n", vector_id, $count));
+
+                vector_id += 1;
+            };
+        }
+
+        let kernel_stat = kernel_metadata().stat();
+
+        add_field!(kernel_stat.syscall_count());
+        add_field!(kernel_stat.timer_interrupts());
+        add_field!(kernel_stat.software_interrupts());
+        // TODO: Add more
+
+        let _ = vector_id; // supress unused assignment warning
+
+        content
+    }
+}
+
+impl IInode for ProcInterrputsInode {
+    fn metadata(&self) -> InodeMetadata {
+        InodeMetadata {
+            filename: "interrupts",
+            entry_type: filesystem_abstractions::DirectoryEntryType::File,
+            size: 0, // Linux treat this as an empty file unless you read it
+        }
+    }
+
+    fn readat(&self, offset: usize, buffer: &mut [u8]) -> FileSystemResult<usize> {
+        let content = self.generate_content();
+        let bytes = content.as_bytes();
+
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+
+        let bytes_to_copy = bytes.len() - offset;
+
+        buffer[..bytes_to_copy].copy_from_slice(&bytes[offset..]);
+
+        Ok(bytes_to_copy)
+    }
+
+    fn writeat(&self, _offset: usize, _buffer: &[u8]) -> FileSystemResult<usize> {
+        Err(FileSystemError::NotPermitted)
+    }
+
+    fn renaming(&self, _new_name: &str) -> FileSystemResult<()> {
+        Err(FileSystemError::NotPermitted)
+    }
+
+    fn removing(&self) -> FileSystemResult<()> {
+        Err(FileSystemError::NotPermitted)
     }
 }


### PR DESCRIPTION
This passes [tests](https://github.com/oscomp/testsuits-for-oskernel/tree/final-2025/interrupts-test) on risc-v and loongarch.

FIXME:
- [X] ~~In 4efeca450ab5d76a999337f72201440a6d19c2ac, there's no output in test `interrupts-test2-glibc`. [CI runs](https://github.com/caiyih/bakaos/actions/runs/16489808327)~~ Confirmed to be a wired testsuit issue, fixed by recompiling.
- [X] [loongarch64] [Regression] ~~Busybox tests `mv test_dir test` fails~~ fixed in 4efeca450ab5d76a999337f72201440a6d19c2ac...5e2976b04073880307e62c75bf3bec0d24b454df
