### PR TITLE
Feat: Implement `copy_file_range` syscall

### DIFF
--- a/crates/platform-specific/src/loongarch64/syscall_ids.rs
+++ b/crates/platform-specific/src/loongarch64/syscall_ids.rs
@@ -54,6 +54,7 @@ pub const SYSCALL_ID_MMAP: usize = 222;
 pub const SYSCALL_ID_WAIT4: usize = 260;
 pub const SYSCALL_ID_PRLIMIT64: usize = 261;
 pub const SYSCALL_ID_GETRANDOM: usize = 278;
+pub const SYSCALL_ID_COPY_FILE_RANGE: usize = 285;
 pub const SYSCALL_ID_STATX: usize = 291;
 pub const SYSCALL_ID_CLOCK_GETTIME: usize = 113;
 

--- a/crates/platform-specific/src/riscv64/syscall_ids.rs
+++ b/crates/platform-specific/src/riscv64/syscall_ids.rs
@@ -56,5 +56,6 @@ pub const SYSCALL_ID_MMAP: usize = 222;
 pub const SYSCALL_ID_WAIT4: usize = 260;
 pub const SYSCALL_ID_PRLIMIT64: usize = 261;
 pub const SYSCALL_ID_GETRANDOM: usize = 278;
+pub const SYSCALL_ID_COPY_FILE_RANGE: usize = 285;
 pub const SYSCALL_ID_STATX: usize = 291;
 pub const SYSCALL_ID_CLOCK_GETTIME: usize = 113;

--- a/kernel/src/syscalls/mod.rs
+++ b/kernel/src/syscalls/mod.rs
@@ -25,6 +25,8 @@ use task_async::{sys_nanosleep_async, sys_sched_yield_async, sys_wait4_async};
 use platform_specific::{syscall_ids::*, ISyscallContext};
 use tasks::SyscallContext;
 
+use crate::syscalls::file_async::sys_copy_file_range;
+
 mod file;
 mod file_async;
 mod futex_async;
@@ -130,6 +132,7 @@ impl SyscallDispatcher {
             SYSCALL_ID_PPOLL => Some(sys_ppoll_async(ctx).await),
             SYSCALL_ID_PREAD => Some(sys_pread_async(ctx).await),
             SYSCALL_ID_PWRITE => Some(sys_pwrite_async(ctx).await),
+            SYSCALL_ID_COPY_FILE_RANGE => Some(sys_copy_file_range(ctx).await),
             _ => None,
         }
     }


### PR DESCRIPTION
This passes [tests](https://github.com/oscomp/testsuits-for-oskernel/tree/final-2025/copy-file-range-test) on risc-v and loongarch. CI runs [here](https://github.com/caiyih/bakaos/actions/runs/16492893647/job/46631666343)