### PR TITLE
Fix: correct argument handling in task initialization

### DIFF
--- a/crates/platform-specific/src/loongarch64/context.rs
+++ b/crates/platform-specific/src/loongarch64/context.rs
@@ -124,7 +124,7 @@ impl ITaskContext for TaskTrapContext {
         entry_pc: usize,
         stack_top: usize,
         _argc: usize,
-        argv_base: usize,
+        _argv_base: usize,
         _envp_base: usize,
     ) -> Self {
         const PPLV_UMODE: usize = 0b11;
@@ -135,7 +135,7 @@ impl ITaskContext for TaskTrapContext {
         ctx.era = entry_pc;
         ctx.prmd = PPLV_UMODE | PIE;
 
-        ctx.regs.a0 = argv_base;
+        ctx.regs.a0 = 0;
 
         ctx
     }

--- a/crates/platform-specific/src/riscv64/context.rs
+++ b/crates/platform-specific/src/riscv64/context.rs
@@ -172,9 +172,9 @@ impl ITaskContext for TaskTrapContext {
     fn new(
         entry_pc: usize,
         stack_top: usize,
-        argc: usize,
-        argv_base: usize,
-        envp_base: usize,
+        _argc: usize,
+        _argv_base: usize,
+        _envp_base: usize,
     ) -> Self {
         let mut ctx = unsafe { core::mem::zeroed::<TaskTrapContext>() };
         ctx.sepc = entry_pc;
@@ -188,9 +188,7 @@ impl ITaskContext for TaskTrapContext {
 
         ctx.sstatus = unsafe { core::mem::transmute::<Sstatus, usize>(sstatus) };
 
-        ctx.regs.a0 = argc;
-        ctx.regs.a1 = argv_base;
-        ctx.regs.a2 = envp_base;
+        ctx.regs.a0 = 0;
 
         ctx
     }


### PR DESCRIPTION
- LoongArch64: Replace `argv_base` with `_argv_base` and set `a0` to 0
- RISC-V64: Replace `argc`, `argv_base`, and `envp_base` with unused placeholders and set `a0` to 0
- This change is intended to match `start.S` in glibc and `crt_arch.h` in musl
