### PR TITLE
ci: Disable `fail_ci_if_error` when upload coverage to codedov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/cobertura.xml
-          fail_ci_if_error: true


### PR DESCRIPTION
This prevents CI failures in forks, allowing developers to view test results through the CI status.