### PR TITLE
ci: Split test to a separate job with `cargo nextest` and `test reporter` 

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.default.junit]
+path = "junit.xml"
+store-success-output = true
+store-failure-output = true

--- a/.github/workflows/actions/setup-cargo-binstall/action.yml
+++ b/.github/workflows/actions/setup-cargo-binstall/action.yml
@@ -18,4 +18,4 @@ runs:
 
   - name: Verify installation
     shell: bash
-    run: cargo binstall
+    run: cargo binstall -h

--- a/.github/workflows/actions/setup-cargo-binstall/action.yml
+++ b/.github/workflows/actions/setup-cargo-binstall/action.yml
@@ -1,4 +1,4 @@
-name: Install tarpaulin with cargo-binstall
+name: Install cargo-binstall
 
 runs:
   using: composite
@@ -16,10 +16,6 @@ runs:
     run: |
       Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
 
-  - name: Install cargo-tarpaulin
-    shell: bash
-    run: cargo binstall cargo-tarpaulin
-
   - name: Verify installation
     shell: bash
-    run: cargo tarpaulin --version
+    run: cargo binstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           path: target/nextest/default/junit.xml
 
   coverage:
-    name: Coverage collection
+    name: Coverage
     runs-on: ${{ matrix.os.fullname }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,17 @@ jobs:
           rustup default ${{ env.TOOLCHAIN_VERSION }}
           rustup override set ${{ env.TOOLCHAIN_VERSION }}
 
-      - name: Setup tarpaulin
-        uses: ./.github/workflows/actions/setup-tarpaulin
+      - name: Setup Cargo-binstall
+        uses: ./.github/workflows/actions/setup-cargo-binstall
+
+      - name: Install cargo-tarpaulin
+        shell: bash
+        run: |
+          cargo binstall cargo-tarpaulin
+          cargo tarpaulin --version
 
       - name: Compile
-        run: cargo build
+        run: cargo test --no-run
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ${{matrix.os.fullname}}
+    runs-on: ${{ matrix.os.fullname }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,9 +53,19 @@ jobs:
 
       - name: Upload Test Report to artifact
         uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
           name: report-${{ matrix.os.prettyname }}
           path: target/nextest/default/junit.xml
+
+      - name: Annotate CI run with test results 
+        uses: Cai1Hsu/test-reporter@main
+        if: ${{ !cancelled() }}
+        with:
+          name: Results
+          path: "target/nextest/default/junit.xml"
+          reporter: nextest-junit
+          list-tests: 'failed'
 
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: Test
-    runs-on: ${{matrix.os.fullname}}
+  coverage:
+    name: Coverage collection
+    runs-on: ${{ matrix.os.fullname }}
     strategy:
       fail-fast: false
       matrix:
         os:
-          - { prettyname: Windows, fullname: windows-latest }
+          # This workflow only collects coverage, to run on Windows is a waste of resources
           - { prettyname: Linux, fullname: ubuntu-latest }
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           RUST_LOG: "trace"
           RUST_BACKTRACE: "1"
         run: |
-          cargo nextest run --no-fail-fast --hide-progress-bar --success-output immediate --failure-output immediate --profile ci
+          cargo nextest run --no-fail-fast --hide-progress-bar --success-output immediate --failure-output immediate
 
       - name: Upload Test Report to artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,53 @@ on:
   pull_request:
 
 jobs:
+  test:
+    name: Test
+    runs-on: ${{matrix.os.fullname}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { prettyname: Linux, fullname: ubuntu-latest }
+          - { prettyname: Windows, fullname: windows-latest }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        env:
+          TOOLCHAIN_VERSION: nightly-2025-02-01
+        run: |
+          rustup toolchain install ${{ env.TOOLCHAIN_VERSION }} --profile minimal
+          rustup default ${{ env.TOOLCHAIN_VERSION }}
+          rustup override set ${{ env.TOOLCHAIN_VERSION }}
+
+      - name: Setup Cargo-binstall
+        uses: ./.github/workflows/actions/setup-cargo-binstall
+
+      - name: Install cargo-nextest
+        shell: bash
+        run: |
+          cargo binstall cargo-nextest
+          cargo nextest --version
+
+      - name: Compile
+        run: cargo nextest run --no-run
+
+      - name: Test
+        env:
+          RUST_LOG: "trace"
+          RUST_BACKTRACE: "1"
+        run: |
+          cargo nextest run --no-fail-fast --hide-progress-bar --success-output immediate --failure-output immediate --profile ci
+
+      - name: Upload Test Report to artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-${{ matrix.os.prettyname }}
+          path: target/nextest/default/junit.xml
+
   coverage:
     name: Coverage collection
     runs-on: ${{ matrix.os.fullname }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   push:
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: 'always'
+  TOOLCHAIN_VERSION: 'nightly-2025-02-01'
+
 jobs:
   test:
     name: Test
@@ -23,8 +27,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        env:
-          TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install ${{ env.TOOLCHAIN_VERSION }} --profile minimal
           rustup default ${{ env.TOOLCHAIN_VERSION }}
@@ -70,8 +72,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        env:
-          TOOLCHAIN_VERSION: nightly-2025-02-01
         run: |
           rustup toolchain install ${{ env.TOOLCHAIN_VERSION }} --profile minimal
           rustup default ${{ env.TOOLCHAIN_VERSION }}


### PR DESCRIPTION
[Nextest](https://nexte.st/) produces output in the [JUnit XML format](https://llg.cubic.org/docs/junit/). And [test-reporter](https://github.com/cai1hsu/test-reporter)(My fork of [`dorny/test-reporter`](https://github.com/dorny/test-reporter)) creates action summary and failure annotations for the runs.