### PR TITLE
ci: fix transformer in JUnit report

### DIFF
--- a/.github/workflows/report-junit.yml
+++ b/.github/workflows/report-junit.yml
@@ -43,7 +43,7 @@ jobs:
           truncate_stack_traces: false
           check_title_template: "{{SUITE_NAME}}::{{TEST_NAME}}"
           transformers: |
-            [{"searchValue":"\\","replaceValue":"/"}]
+            [{"searchValue":"\\\\","replaceValue":"/"}]
           detailed_summary: true
           follow_symlink: true
           comment: true


### PR DESCRIPTION
- Update the stacktrace transformer to correctly replace backslashes in Windows paths
- Change '\\' to '\\' in the searchValue for proper escaping