### PR TITLE
ci: handle reporting test results for PRs

### DIFF
--- a/.github/workflows/report-junit.yml
+++ b/.github/workflows/report-junit.yml
@@ -33,6 +33,48 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      # When the triggering workflow is running in a restricted security context, some
+      # data is omitted from `github.event.workflow_run` (including `pull_requests`).
+      # Therefore, we have to take some extra steps to find out the PR that triggered
+      # the original workflow. The simplest way is to iterate through our open PRs and
+      # find the one with the same head SHA as the triggering workflow.
+      - name: Try to find PR number
+        id: get-pr-number
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const per_page = 100;
+
+            const head_sha = "${{ github.event.workflow_run.head_sha }}";
+            console.log("Finding PR for SHA:", head_sha);
+
+            let page = 1;
+
+            while (true) {
+                console.log("Loading Page:", page);
+
+                const { data: prs } = await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    per_page: per_page,
+                    page: page,
+                    state: "open",
+                });
+
+                const pr = prs.find(pr => pr.head.sha === head_sha);
+
+                if (pr) {
+                    console.log("Found PR:", pr.number);
+                    return pr.number;
+                }
+
+                if (prs.length < per_page) {
+                    break;
+                }
+
+                page++;
+            }
+
       - name: Annotate CI run with test results
         uses: mikepenz/action-junit-report@v5
         with:
@@ -47,4 +89,4 @@ jobs:
           detailed_summary: true
           follow_symlink: true
           comment: true
-          pr_id: ${{ github.event.workflow_run.pull_requests[0].number }}
+          pr_id: ${{ steps.get-pr-number.outputs.result }}

--- a/.github/workflows/report-junit.yml
+++ b/.github/workflows/report-junit.yml
@@ -59,6 +59,8 @@ jobs:
                     per_page: per_page,
                     page: page,
                     state: "open",
+                    sort: "updated",
+                    direction: "desc",
                 });
 
                 const pr = prs.find(pr => pr.head.sha === head_sha);


### PR DESCRIPTION
When the triggering workflow is running in a restricted security context, some data is omitted from `github.event.workflow_run` (including `pull_requests`). This commit adds a step to find the PR number by iterating through open PRs and matching the head SHA. This ensures that test results can still be reported for PRs in such restricted contexts.

- Added 'Get PR number' step to find the PR with the same head SHA as the triggering workflow
- Updated 'Annotate CI run with test results' step to use the new PR number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test report annotations now reliably appear on pull requests even when PR metadata is restricted, improving CI visibility.

* **Chores**
  * CI workflow enhanced to robustly identify the associated pull request for a run, ensuring consistent JUnit report annotations across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->