### PR TITLE
ci: Fixed  `action-junit-report` complaining about invalid regular expressions

### DIFF
--- a/.github/workflows/report-junit.yml
+++ b/.github/workflows/report-junit.yml
@@ -87,7 +87,7 @@ jobs:
           truncate_stack_traces: false
           check_title_template: "{{SUITE_NAME}}::{{TEST_NAME}}"
           transformers: |
-            [{"searchValue":"\\\\","replaceValue":"/"}]
+            [{"searchValue":"\\\\\\\\","replaceValue":"/"}]
           detailed_summary: true
           follow_symlink: true
           comment: true

--- a/.github/workflows/report-junit.yml
+++ b/.github/workflows/report-junit.yml
@@ -87,7 +87,7 @@ jobs:
           truncate_stack_traces: false
           check_title_template: "{{SUITE_NAME}}::{{TEST_NAME}}"
           transformers: |
-            [{"searchValue":"\\\\\\\\","replaceValue":"/"}]
+            [{"searchValue":"\\\\\\","replaceValue":"/"}]
           detailed_summary: true
           follow_symlink: true
           comment: true

--- a/.github/workflows/report-junit.yml
+++ b/.github/workflows/report-junit.yml
@@ -87,7 +87,7 @@ jobs:
           truncate_stack_traces: false
           check_title_template: "{{SUITE_NAME}}::{{TEST_NAME}}"
           transformers: |
-            [{"searchValue":"\\","replaceValue":"/"}]
+            [{"searchValue":"\\\\","replaceValue":"/"}]
           detailed_summary: true
           follow_symlink: true
           comment: true


### PR DESCRIPTION
We attempted to convert all Windows-style paths to UNIX-style by specifying transformers to `\\` -> `/` in previous commits. But it didn't seem to work and resulted in a complaint in every CI run.

runs [here](https://github.com/caiyih/bakaos/actions/runs/16996411584/job/48188090056), or the complaint:
```
Bad replacer regex: \ (SyntaxError: Invalid regular expression: /\/gu: \ at end of pattern)
```

I don't know(and probably never want to know) why we should use six backslashes, but it just works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated CI test-report transformation to handle increased escaping of backslashes, improving robustness of report parsing across environments.
* Tests
  * Improved normalization of path separators in JUnit report processing so test results and artifacts display consistently and readably in dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->