### PR TITLE
feat(address): implement more into for VirtualAddress

### DIFF
--- a/libraries/address/src/lib.rs
+++ b/libraries/address/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(cfg_accessible)]
 #![feature(const_trait_impl)]
 #![feature(debug_closure_helpers)]
+#![feature(specialization)]
+#![allow(incomplete_features)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]

--- a/libraries/address/src/virtual_address.rs
+++ b/libraries/address/src/virtual_address.rs
@@ -14,16 +14,24 @@ impl<T> Into<VirtualAddress> for *const T {
     }
 }
 
-impl<T> Into<VirtualAddress> for &[T] {
-    fn into(self) -> VirtualAddress {
-        VirtualAddress::from_ptr(self.as_ptr())
+impl<T> From<&T> for VirtualAddress {
+    default fn from(value: &T) -> Self {
+        VirtualAddress::from_ref(value)
     }
 }
 
-impl<T, const N: usize> Into<VirtualAddress> for &[T; N] {
-    #[inline(always)]
-    fn into(self) -> VirtualAddress {
-        VirtualAddress::from_ptr(self.as_ptr())
+impl<T> From<&T> for VirtualAddress
+where
+    T: core::ops::Deref,
+{
+    default fn from(value: &T) -> Self {
+        VirtualAddress::from_ptr(value.deref() as *const _ as *const ())
+    }
+}
+
+impl<T> From<&[T]> for VirtualAddress {
+    default fn from(value: &[T]) -> Self {
+        value.as_ptr().into()
     }
 }
 


### PR DESCRIPTION
This PR adds more `into VirtualAddress` conversion ability for various types, especially on &T and &impl Deref.

- Add specialization feature(necessary to impl trait for both &impl Deref and &T) to allow for more specific implementations
- Implement From trait for &T, &[T] and impl Deref references
- implementations for impl Deref types are on reference to avoid taking ownership. You can use `box.as_ref().into()` for values
