### PR TITLE
build: Bump rust toolchain version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(error "Please specify a valid architecture like `make build ARCH=<arch>` where
 endif
 
 build:
-	cd kernel && cargo +nightly build -Z build-std=core,alloc --target $(TARGET)
+	cd kernel && cargo build -Z build-std=core,alloc --target $(TARGET)
 	cp kernel/target/$(TARGET)/debug/$(OUTPUT) kernel-$(ARCH).bin
 
 run: build
@@ -25,3 +25,4 @@ run: build
 		-smp 1 \
 		-m 1G \
 		-kernel kernel-$(ARCH).bin
+

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(error "Please specify a valid architecture like `make build ARCH=<arch>` where
 endif
 
 build:
-	cd kernel && cargo build --target $(TARGET)
+	cd kernel && cargo +nightly build -Z build-std=core,alloc --target $(TARGET)
 	cp kernel/target/$(TARGET)/debug/$(OUTPUT) kernel-$(ARCH).bin
 
 run: build

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -5,7 +5,8 @@ rustflags = [
 
 [target.loongarch64-unknown-none]
 rustflags = [
-    "-Clink-arg=-Tlds/la64.ld", "-Cforce-frame-pointers=yes"
+    "-Clink-arg=-Tlds/la64.ld", "-Cforce-frame-pointers=yes",
+    "-C", "target-feature=-lsx,-lasx"
 ]
 
 # ------------------------------------------------------------

--- a/libraries/platform-abstractions/src/lib.rs
+++ b/libraries/platform-abstractions/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(linkage)]
-#![feature(naked_functions)]
 #![feature(panic_can_unwind)]
 
 extern crate alloc;

--- a/libraries/platform-abstractions/src/loongarch64/boot.rs
+++ b/libraries/platform-abstractions/src/loongarch64/boot.rs
@@ -10,7 +10,7 @@ use loongArch64::{
 
 use crate::{clear_bss, loongarch64::context::init_thread_info};
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[link_section = ".text.entry"] // Don't rename, cross crates inter-operation
 #[allow(clippy::missing_safety_doc)]

--- a/libraries/platform-abstractions/src/loongarch64/trap/kernel.rs
+++ b/libraries/platform-abstractions/src/loongarch64/trap/kernel.rs
@@ -3,7 +3,7 @@ use core::arch::naked_asm;
 use loongArch64::register::estat;
 use platform_specific::TaskTrapContext;
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 unsafe extern "C" fn __on_kernel_trap() {
     naked_asm!(

--- a/libraries/platform-abstractions/src/loongarch64/trap/user.rs
+++ b/libraries/platform-abstractions/src/loongarch64/trap/user.rs
@@ -10,7 +10,7 @@ use trap_abstractions::ITaskTrapContext;
 
 use crate::UserInterrupt;
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 unsafe extern "C" fn __on_user_trap() {
     naked_asm!(
@@ -95,7 +95,7 @@ unsafe extern "C" fn __on_user_trap() {
     )
 }
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 pub unsafe extern "C" fn __return_to_user(p_ctx: &mut TaskTrapContext) {
     naked_asm!(

--- a/libraries/platform-abstractions/src/riscv64/boot.rs
+++ b/libraries/platform-abstractions/src/riscv64/boot.rs
@@ -3,7 +3,7 @@ use ::core::arch::naked_asm;
 use super::context::init_thread_info;
 use crate::clear_bss;
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[link_section = ".text.entry"]
 #[allow(clippy::missing_safety_doc)]
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn _start() -> ! {
     )
 }
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[link_section = ".text.entry"]
 unsafe extern "C" fn _start_virtualized() -> ! {

--- a/libraries/platform-abstractions/src/riscv64/trap/kernel.rs
+++ b/libraries/platform-abstractions/src/riscv64/trap/kernel.rs
@@ -18,7 +18,7 @@ pub fn set_kernel_trap_handler() {
     unsafe { stvec::write(__on_kernel_trap as usize, stvec::TrapMode::Direct) };
 }
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[link_section = ".text.trampoline_kernel"]
 unsafe extern "C" fn __on_kernel_trap() {

--- a/libraries/platform-abstractions/src/riscv64/trap/user.rs
+++ b/libraries/platform-abstractions/src/riscv64/trap/user.rs
@@ -22,7 +22,7 @@ fn set_user_trap_handler() {
     unsafe { stvec::write(__on_user_trap as usize, stvec::TrapMode::Direct) };
 }
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[link_section = ".text.trampoline_user"]
 unsafe extern "C" fn __on_user_trap() {
@@ -94,7 +94,7 @@ unsafe extern "C" fn __on_user_trap() {
     );
 }
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 pub unsafe extern "C" fn __return_to_user(p_ctx: &mut TaskTrapContext) {
     // Layout of TaskTrapContext, see src/tasks/user_task.rs for details:

--- a/libraries/platform-specific/src/lib.rs
+++ b/libraries/platform-specific/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(naked_functions)]
 #![feature(stmt_expr_attributes)]
 
 #[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2025-02-01"
+channel = "nightly-2025-08-07"
 targets = ["riscv64gc-unknown-none-elf", "loongarch64-unknown-none"]
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]


### PR DESCRIPTION
This PR bumps the Rust toolchain version to a rather new one to keep up with the upstream. 

There are a lot of lint issues generated. We will fix them in the coming PRs. This PR only ensures that all code is compiled and run.

We've also encountered some instruction selection issues. The new toolchain seems to stabilize SIMD support for LoongArch and generate a lot of SIMD instructions in our code and in the standard library( They are not supported by QEMU and most of the loongarch hardwares). We added flags to disable lsx and lasx to avoid them. Also, we have to compile the standard library ourselves because they are provided in binary form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated Rust toolchain to nightly-2025-08-07.
  - Build now uses nightly build-std (core, alloc) for cross-targets.
  - Disabled LSX/LASX CPU features for LoongArch to improve compatibility.

- Refactor
  - Modernized naked-function annotations to the newer unsafe(naked) form and removed related nightly feature gates; no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->