### PR TITLE
Add comprehensive docstrings for libraries/utilities crate

### DIFF
--- a/libraries/utilities/src/invoke_on_drop.rs
+++ b/libraries/utilities/src/invoke_on_drop.rs
@@ -1,8 +1,124 @@
+//! # RAII Cleanup with InvokeOnDrop
+//!
+//! This module provides the [`InvokeOnDrop`] type, a RAII (Resource Acquisition Is Initialization)
+//! guard that automatically executes cleanup code when a value goes out of scope.
+//!
+//! ## Purpose
+//!
+//! In systems programming, especially in kernel development, proper resource management is crucial.
+//! The [`InvokeOnDrop`] type ensures that cleanup operations are automatically performed when values
+//! go out of scope, preventing resource leaks and ensuring deterministic cleanup behavior.
+//!
+//! ## Key Features
+//!
+//! - **Automatic Cleanup**: Executes cleanup functions when the guard is dropped
+//! - **Value Management**: Can manage and provide access to wrapped values
+//! - **Cancellation Support**: Allows cancelling cleanup operations when needed
+//! - **Zero Runtime Cost**: Uses compile-time guarantees with no runtime overhead
+//! - **no_std Compatible**: Works in kernel and embedded environments
+//!
+//! ## Use Cases
+//!
+//! - **Resource Management**: Automatically releasing acquired resources (memory, file handles, locks)
+//! - **Cleanup Operations**: Ensuring cleanup code runs even during early returns or panics
+//! - **Scope Guards**: Implementing defer-like functionality for cleanup tasks
+//! - **Exception Safety**: Maintaining invariants in the presence of panics or early exits
+//!
+//! ## Examples
+//!
+//! ### Basic cleanup operation
+//!
+//! ```
+//! use utilities::InvokeOnDrop;
+//!
+//! fn some_operation() {
+//!     // Setup some resource or state
+//!     let _cleanup_guard = InvokeOnDrop::new(|_| {
+//!         // This cleanup code will run when the function exits,
+//!         // regardless of how it exits (return, panic, etc.)
+//!         println!("Cleaning up resources...");
+//!     });
+//!
+//!     // Do work...
+//!     // Cleanup happens automatically when _cleanup_guard goes out of scope
+//! }
+//! ```
+//!
+//! ### Managing a resource with automatic release
+//!
+//! ```
+//! use utilities::InvokeOnDrop;
+//!
+//! fn process_resource() {
+//!     let resource_id = acquire_some_resource();
+//!     let _guard = InvokeOnDrop::transform(resource_id, |id| {
+//!         release_resource(id);
+//!     });
+//!
+//!     // Use the resource through the guard
+//!     println!("Resource ID: {}", *_guard);
+//!
+//!     // Resource is automatically released when guard goes out of scope
+//! }
+//!
+//! fn acquire_some_resource() -> u32 { 42 }
+//! fn release_resource(id: u32) { /* cleanup logic */ }
+//! ```
+
 use core::{
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
 };
 
+/// A RAII guard that automatically invokes a closure when dropped.
+///
+/// `InvokeOnDrop` provides a way to ensure that cleanup code is executed when a value
+/// goes out of scope, similar to destructors in C++ or `defer` statements in other languages.
+/// This is particularly useful in systems programming where manual resource management
+/// is required.
+///
+/// The guard holds both a value of type `T` and a closure of type `F` that takes `T`
+/// as its parameter. When the guard is dropped, the closure is called with the value.
+///
+/// # Type Parameters
+///
+/// * `T` - The type of the value to be managed
+/// * `F` - The type of the cleanup closure, must implement `FnOnce(T)`
+///
+/// # Examples
+///
+/// ## Basic cleanup
+///
+/// ```
+/// use utilities::InvokeOnDrop;
+/// use std::sync::{Arc, Mutex};
+///
+/// let flag = Arc::new(Mutex::new(false));
+/// let flag_clone = flag.clone();
+///
+/// {
+///     let _guard = InvokeOnDrop::new(|_| {
+///         *flag_clone.lock().unwrap() = true;
+///     });
+///     // flag is still false here
+/// }
+/// // flag is now true - cleanup was executed
+/// ```
+///
+/// ## Managing a resource with automatic cleanup
+///
+/// ```
+/// use utilities::InvokeOnDrop;
+///
+/// fn acquire_resource() -> i32 { 42 }
+/// fn release_resource(id: i32) { /* cleanup logic */ }
+///
+/// let resource_id = acquire_resource();
+/// let _guard = InvokeOnDrop::transform(resource_id, |id| {
+///     release_resource(id);
+/// });
+/// // resource will be automatically released when guard goes out of scope
+/// ```
 #[must_use = "hold the guard in a local variable to delay the callback until scope exit"]
 pub struct InvokeOnDrop<T, F: FnOnce(T)> {
     func: ManuallyDrop<F>,
@@ -10,6 +126,29 @@ pub struct InvokeOnDrop<T, F: FnOnce(T)> {
 }
 
 impl<F: FnOnce(())> InvokeOnDrop<(), F> {
+    /// Creates a new `InvokeOnDrop` guard with a unit value.
+    ///
+    /// This is a convenience method for when you only need to execute cleanup
+    /// code without managing a specific value.
+    ///
+    /// # Parameters
+    ///
+    /// * `func` - The cleanup closure to invoke when the guard is dropped
+    ///
+    /// # Returns
+    ///
+    /// A new `InvokeOnDrop` guard that will execute `func` on drop
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use utilities::InvokeOnDrop;
+    ///
+    /// let _guard = InvokeOnDrop::new(|_| {
+    ///     println!("Cleanup executed!");
+    /// });
+    /// // "Cleanup executed!" will be printed when guard goes out of scope
+    /// ```
     #[inline]
     pub fn new(func: F) -> Self {
         Self::transform((), func)
@@ -17,6 +156,32 @@ impl<F: FnOnce(())> InvokeOnDrop<(), F> {
 }
 
 impl<T, F: FnOnce(T)> InvokeOnDrop<T, F> {
+    /// Creates a new `InvokeOnDrop` guard with a specific value and cleanup function.
+    ///
+    /// This method allows you to associate a cleanup closure with a value. When the
+    /// guard is dropped, the closure will be called with the value as its parameter.
+    ///
+    /// # Parameters
+    ///
+    /// * `val` - The value to be managed by the guard
+    /// * `func` - The cleanup closure that will receive the value when the guard is dropped
+    ///
+    /// # Returns
+    ///
+    /// A new `InvokeOnDrop` guard managing the value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use utilities::InvokeOnDrop;
+    ///
+    /// let guard = InvokeOnDrop::transform(42, |value| {
+    ///     println!("Cleaning up value: {}", value);
+    /// });
+    ///
+    /// assert_eq!(*guard, 42);
+    /// // "Cleaning up value: 42" will be printed when guard goes out of scope
+    /// ```
     #[inline]
     pub fn transform(val: T, func: F) -> Self {
         InvokeOnDrop {
@@ -25,7 +190,36 @@ impl<T, F: FnOnce(T)> InvokeOnDrop<T, F> {
         }
     }
 
-    /// Deconstructs the `InvokeOnDrop`, cancelling the function
+    /// Deconstructs the `InvokeOnDrop` guard, returning the value and function without executing cleanup.
+    ///
+    /// This method allows you to retrieve the managed value and cleanup function without
+    /// triggering the automatic cleanup behavior. This is useful when you want to handle
+    /// the cleanup manually or transfer ownership of the value elsewhere.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing the managed value and the cleanup function
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use utilities::InvokeOnDrop;
+    ///
+    /// let guard = InvokeOnDrop::transform(42, |value| {
+    ///     println!("This won't be printed");
+    /// });
+    ///
+    /// let (value, cleanup_fn) = guard.deconstruct();
+    /// assert_eq!(value, 42);
+    /// // cleanup_fn can be called manually if needed
+    /// cleanup_fn(value); // Now "This won't be printed" is printed
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// This method uses unsafe code to extract values from `ManuallyDrop` and prevent
+    /// the destructor from running. The extracted values are guaranteed to be valid
+    /// as long as the original guard was valid.
     pub fn deconstruct(mut self) -> (T, F) {
         let (val, func) = unsafe {
             (
@@ -39,7 +233,35 @@ impl<T, F: FnOnce(T)> InvokeOnDrop<T, F> {
         (val, func)
     }
 
-    /// Consume the `InvokeOnDrop`, skip the callback, and drop the inner value immediately.
+    /// Consume the `InvokeOnDrop` guard and drop the inner value immediately without executing cleanup.
+    ///
+    /// This method cancels the cleanup operation and immediately drops both the managed
+    /// value and the cleanup function. This is useful when you want to abort the cleanup
+    /// process entirely.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use utilities::InvokeOnDrop;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// let flag = Arc::new(Mutex::new(false));
+    /// let flag_clone = flag.clone();
+    ///
+    /// let guard = InvokeOnDrop::new(|_| {
+    ///     *flag_clone.lock().unwrap() = true;
+    /// });
+    ///
+    /// guard.cancel(); // Cancel the cleanup
+    ///
+    /// // flag remains false because cleanup was cancelled
+    /// assert!(!*flag.lock().unwrap());
+    /// ```
+    ///
+    /// # Note
+    ///
+    /// The value is dropped before the function to ensure proper cleanup order.
+    /// This method uses `deconstruct` internally to avoid issues during stack unwinding.
     pub fn cancel(self) {
         // use deconstruct to avoid drop being called during unwind
         let (val, func) = self.deconstruct();
@@ -49,6 +271,19 @@ impl<T, F: FnOnce(T)> InvokeOnDrop<T, F> {
     }
 }
 
+/// Implementation of the `Drop` trait for `InvokeOnDrop`.
+///
+/// When an `InvokeOnDrop` instance is dropped, this implementation extracts both
+/// the managed value and the cleanup function from their `ManuallyDrop` wrappers
+/// and then invokes the cleanup function with the value.
+///
+/// # Safety
+///
+/// This implementation uses unsafe code to extract values from `ManuallyDrop`.
+/// This is safe because:
+/// - The values are only extracted once during drop
+/// - The extracted values are immediately used and not accessed again
+/// - No other code can access the guard after drop begins
 impl<T, F: FnOnce(T)> Drop for InvokeOnDrop<T, F> {
     fn drop(&mut self) {
         let func = unsafe { ManuallyDrop::take(&mut self.func) };
@@ -59,12 +294,47 @@ impl<T, F: FnOnce(T)> Drop for InvokeOnDrop<T, F> {
 }
 
 impl<T: Copy, F: FnOnce(T)> InvokeOnDrop<T, F> {
+    /// Returns a copy of the managed value.
+    ///
+    /// This method is only available when the managed type `T` implements `Copy`.
+    /// It provides access to the value without consuming the guard.
+    ///
+    /// # Returns
+    ///
+    /// A copy of the managed value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use utilities::InvokeOnDrop;
+    ///
+    /// let guard = InvokeOnDrop::transform(42, |_| {});
+    /// let value_copy = guard.as_val();
+    /// assert_eq!(value_copy, 42);
+    /// // guard is still valid and will execute cleanup when dropped
+    /// ```
     #[inline]
     pub fn as_val(&self) -> T {
         *self.val
     }
 }
 
+/// Implementation of `Deref` trait for `InvokeOnDrop`.
+///
+/// This allows the guard to be transparently used as if it were the managed value.
+/// You can call methods on the managed value directly through the guard.
+///
+/// # Examples
+///
+/// ```
+/// use utilities::InvokeOnDrop;
+///
+/// let guard = InvokeOnDrop::transform(String::from("hello"), |_| {});
+///
+/// // Can use string methods directly on the guard
+/// assert_eq!(guard.len(), 5);
+/// assert!(guard.contains("ell"));
+/// ```
 impl<T, F: FnOnce(T)> Deref for InvokeOnDrop<T, F> {
     type Target = T;
 
@@ -74,6 +344,24 @@ impl<T, F: FnOnce(T)> Deref for InvokeOnDrop<T, F> {
     }
 }
 
+/// Implementation of `DerefMut` trait for `InvokeOnDrop`.
+///
+/// This allows mutable access to the managed value through the guard.
+/// You can modify the managed value, and these changes will be visible
+/// to the cleanup function when it's called.
+///
+/// # Examples
+///
+/// ```
+/// use utilities::InvokeOnDrop;
+///
+/// let mut guard = InvokeOnDrop::transform(42, |final_value| {
+///     println!("Final value: {}", final_value);
+/// });
+///
+/// *guard = 100; // Modify the managed value
+/// // When guard is dropped, cleanup will receive 100, not 42
+/// ```
 impl<T, F: FnOnce(T)> DerefMut for InvokeOnDrop<T, F> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {

--- a/libraries/utilities/src/lib.rs
+++ b/libraries/utilities/src/lib.rs
@@ -1,3 +1,31 @@
+//! # Utilities
+//!
+//! This crate provides utility types and functions for the BakaOS kernel.
+//!
+//! ## Features
+//!
+//! - **RAII Cleanup**: The [`InvokeOnDrop`] type provides automatic cleanup functionality
+//!   by invoking a closure when the value goes out of scope, ensuring proper resource
+//!   management in no_std environments.
+//!
+//! ## no_std Support
+//!
+//! This crate is designed to work in `no_std` environments by default, making it suitable
+//! for kernel-level code. When running tests, the standard library is available.
+//!
+//! ## Example
+//!
+//! ```
+//! use utilities::InvokeOnDrop;
+//!
+//! // Automatically cleanup when guard goes out of scope
+//! let _guard = InvokeOnDrop::new(|_| {
+//!     // cleanup code here
+//!     println!("Cleanup executed!");
+//! });
+//! // cleanup closure is called when _guard is dropped
+//! ```
+
 #![cfg_attr(not(test), no_std)]
 
 mod invoke_on_drop;


### PR DESCRIPTION
Original PR: [@Cai1Hsu/bakaos/pull/3](https://github.com/Cai1Hsu/bakaos/pull/3).

Remember to use rebase merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a generic guard that automatically runs a cleanup action on drop.
  - Supports pairing a value with its cleanup, optional cancellation, and extracting components without triggering cleanup.
  - Provides ergonomic read/write access to the stored value.

- Documentation
  - Added crate-level docs with usage examples and feature overview.
  - Re-exported the new utility at the crate root for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->