### PR TITLE
ci: limit workflow triggers to master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
+    branches: ["master"]
   pull_request:
 
 env:

--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -2,6 +2,7 @@ name: Code Quality
 
 on:
   push:
+    branches: ["master"]
   pull_request:
 
 env:


### PR DESCRIPTION
- Update ci.yml and inspect.yml to only trigger on master branch pushes
- This change helps to reduce unnecessary CI runs and improves efficiency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to run on push events only for the master branch, reducing noise from branch-specific pushes.
  * Pull request checks remain unchanged, ensuring the same validation for contributions.
  * No impact to application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->