### PR TITLE
refactor: Use `MemoryStream` in `linux-loader` crate

### DIFF
--- a/libraries/address/src/address.rs
+++ b/libraries/address/src/address.rs
@@ -23,24 +23,29 @@ pub trait IToPageNum<T>: IAddress
 where
     T: IPageNum,
 {
+    #[inline]
     fn to_floor_page_num(self) -> T {
         T::from_usize(self.as_usize() / constants::PAGE_SIZE)
     }
 
+    #[inline]
     fn to_ceil_page_num(self) -> T {
         T::from_usize(self.as_usize().div_ceil(constants::PAGE_SIZE))
     }
 }
 
 pub trait IAlignableAddress: IAddressBase {
+    #[inline]
     fn is_aligned(self, align: usize) -> bool {
         self.as_usize().is_multiple_of(align)
     }
 
+    #[inline]
     fn is_page_aligned(self) -> bool {
         self.is_aligned(constants::PAGE_SIZE)
     }
 
+    #[inline]
     fn align_up(self, align: usize) -> Self {
         debug_assert!(align.is_power_of_two());
 
@@ -49,6 +54,7 @@ pub trait IAlignableAddress: IAddressBase {
         Self::from_usize(aligned)
     }
 
+    #[inline]
     fn align_down(self, align: usize) -> Self {
         debug_assert!(align.is_power_of_two());
 
@@ -57,10 +63,12 @@ pub trait IAlignableAddress: IAddressBase {
         Self::from_usize(aligned)
     }
 
+    #[inline]
     fn page_down(self) -> Self {
         self.align_down(constants::PAGE_SIZE)
     }
 
+    #[inline]
     fn page_up(self) -> Self {
         self.align_up(constants::PAGE_SIZE)
     }
@@ -70,62 +78,77 @@ pub trait IAlignableAddress: IAddressBase {
 pub trait IAddress:
     [const] IAddressBase + IAlignableAddress + IArithOps + IBitwiseOps + Display
 {
+    #[inline]
     fn add_n<T>(self, n: usize) -> Self {
         self.add_by(size_of::<T>() * n)
     }
 
+    #[inline]
     fn add<T>(self) -> Self {
         self.add_by(size_of::<T>())
     }
 
+    #[inline]
     fn minus_n<T>(self, n: usize) -> Self {
         self.minus_by(size_of::<T>() * n)
     }
 
+    #[inline]
     fn minus<T>(self) -> Self {
         self.minus_by(size_of::<T>())
     }
 
+    #[inline]
     fn minus_by(self, offset: usize) -> Self {
         Self::from_usize(self.as_usize() - offset)
     }
 
+    #[inline]
     fn add_by(self, offset: usize) -> Self {
         Self::from_usize(self.as_usize() + offset)
     }
 
+    #[inline]
     fn off_by(self, offset: isize) -> Self {
         Self::from_usize((self.as_usize() as isize + offset) as usize)
     }
 
+    #[inline]
     fn in_page_offset(self) -> usize {
         self.as_usize() % constants::PAGE_SIZE
     }
 
+    #[inline]
     fn diff(self, other: Self) -> isize {
         (self.as_usize() as i64 - other.as_usize() as i64) as isize
     }
 
+    #[inline]
     fn step_back_n<T>(&mut self, n: usize) {
         self.step_back_by(size_of::<T>() * n);
     }
 
+    #[inline]
     fn step_back<T>(&mut self) {
         self.step_back_by(size_of::<T>());
     }
 
+    #[inline]
     fn step_back_by(&mut self, offset: usize) {
         *self = self.minus_by(offset);
     }
 
+    #[inline]
     fn step_n<T>(&mut self, n: usize) {
         self.step_by(size_of::<T>() * n);
     }
 
+    #[inline]
     fn step<T>(&mut self) {
         self.step_by(size_of::<T>());
     }
 
+    #[inline]
     fn step_by(&mut self, offset: usize) {
         *self = self.add_by(offset);
     }

--- a/libraries/linux-loader/Cargo.toml
+++ b/libraries/linux-loader/Cargo.toml
@@ -14,6 +14,7 @@ mmu-abstractions = { path = "../mmu-abstractions" }
 allocation-abstractions = { path = "../allocation-abstractions", default-features = false }
 filesystem-abstractions = { path = "../filesystem-abstractions", default-features = false }
 memory-space = { path = "../memory-space", default-features = false }
+stream = { path = "../stream", default-features = false }
 
 bitflags = "2.9"
 xmas-elf = "0.10"

--- a/libraries/linux-loader/Cargo.toml
+++ b/libraries/linux-loader/Cargo.toml
@@ -21,6 +21,9 @@ xmas-elf = "0.10"
 log = "0.4.27"
 hermit-sync = "0.1.6"
 
+[dev-dependencies]
+test-utilities = { path = "../../test-utilities", default-features = false }
+
 [features]
 default = ["no_std"]
 std = []

--- a/libraries/linux-loader/src/loader.rs
+++ b/libraries/linux-loader/src/loader.rs
@@ -357,7 +357,9 @@ impl StackLoader<'_> {
     pub fn push<T: Copy>(&mut self, value: T) {
         let stack_top = self.seek(Whence::Offset(-(core::mem::size_of::<T>() as isize)));
 
-        debug_assert!(stack_top.as_usize() % core::mem::align_of::<T>() == 0);
+        debug_assert!(stack_top
+            .as_usize()
+            .is_multiple_of(core::mem::align_of::<T>()));
 
         *self.pwrite().unwrap() = value;
     }
@@ -370,11 +372,11 @@ impl StackLoader<'_> {
     /// The slice is copied into the loader's memory space.
     #[inline]
     pub fn push_array<T: Copy>(&mut self, array: &[T]) {
-        let stack_top = self.seek(Whence::Offset(
-            -((core::mem::size_of::<T>() * array.len()) as isize),
-        ));
+        let stack_top = self.seek(Whence::Offset(-(core::mem::size_of_val(array) as isize)));
 
-        debug_assert!(stack_top.as_usize() % core::mem::align_of::<T>() == 0);
+        debug_assert!(stack_top
+            .as_usize()
+            .is_multiple_of(core::mem::align_of::<T>()));
         self.pwrite_slice(array.len())
             .unwrap()
             .copy_from_slice(array);

--- a/libraries/linux-loader/src/loader.rs
+++ b/libraries/linux-loader/src/loader.rs
@@ -652,9 +652,7 @@ mod tests {
         let envp_pointers = stream
             .read_unsized_slice::<VirtualAddress>(|ptr, _| !ptr.is_null())
             .unwrap()
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
+            .to_vec();
 
         assert!(
             stream.read::<VirtualAddress>().unwrap().is_null(),

--- a/libraries/linux-loader/src/loader.rs
+++ b/libraries/linux-loader/src/loader.rs
@@ -258,7 +258,7 @@ impl<'a> LinuxLoader<'a> {
         let mut envps = Vec::new(); // envp pointers
 
         // Step1: Copy envp strings vector to the stack
-        for env in self.ctx.envp.iter().rev() {
+        for env in self.ctx.envp.iter() {
             loader.push(0u8); // NULL-terminated
             loader.push_array(env.as_bytes());
             envps.push(loader.cursor());
@@ -267,7 +267,7 @@ impl<'a> LinuxLoader<'a> {
         let mut argvs = Vec::new(); // argv pointers
 
         // Step2: Copy args strings vector to the stack
-        for arg in self.ctx.argv.iter().rev() {
+        for arg in self.ctx.argv.iter() {
             loader.push(0u8); // NULL-terminated
             loader.push_array(arg.as_bytes());
             argvs.push(loader.cursor());

--- a/libraries/linux-loader/src/loader.rs
+++ b/libraries/linux-loader/src/loader.rs
@@ -307,12 +307,7 @@ impl<'a> LinuxLoader<'a> {
         let auxv = self.ctx.auxv.collect();
 
         // Push other auxv entries
-        // TODO: can we use loader.push_array(auxv) here?
-        // Investigate the AuxVecEntry's layout
-        for aux in auxv.iter().rev() {
-            loader.push(aux.value);
-            loader.push(aux.key);
-        }
+        loader.push_array(&auxv);
 
         // Ensure that the last entry is AT_NULL
         debug_assert_eq!(auxv.iter().last().unwrap().key, AuxVecKey::AT_NULL);

--- a/libraries/linux-loader/src/loader.rs
+++ b/libraries/linux-loader/src/loader.rs
@@ -309,7 +309,7 @@ impl<'a> LinuxLoader<'a> {
         // Push other auxv entries
         // TODO: can we use loader.push_array(auxv) here?
         // Investigate the AuxVecEntry's layout
-        for aux in auxv.iter() {
+        for aux in auxv.iter().rev() {
             loader.push(aux.value);
             loader.push(aux.key);
         }

--- a/libraries/linux-loader/src/loader.rs
+++ b/libraries/linux-loader/src/loader.rs
@@ -289,7 +289,7 @@ impl<'a> LinuxLoader<'a> {
 
             // Ensure that start address of copied PLATFORM is aligned to 8 bytes
             loader.seek(Whence::Offset(-(len as isize)));
-            loader.ensure_alignment::<usize>();
+            loader.ensure_alignment::<u64>(); // 8 bytes alignment
             loader.seek(Whence::Offset(len as isize));
 
             loader.push(0u8); // ensure null termination

--- a/libraries/linux-loader/src/loader.rs
+++ b/libraries/linux-loader/src/loader.rs
@@ -463,3 +463,285 @@ impl LoadError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use address::{IToPageNum, VirtualPageNumRange};
+    use memory_space::MappingArea;
+    use mmu_abstractions::{GenericMappingFlags, PageSize};
+    use stream::MemoryStream;
+    use test_utilities::allocation::contiguous::TestFrameAllocator;
+
+    use super::*;
+
+    fn test_scene(ctx: ProcessContext<'_>, action: impl FnOnce(LinuxLoader<'_>)) {
+        let (alloc, mmu) = TestFrameAllocator::new_with_mmu(1024 * 1024 * 1024);
+
+        let mut memory_space = MemorySpace::new(mmu, alloc);
+
+        // Allocate 2 MB for the stack.
+        let stack_base = VirtualAddress::from_usize(0x80000000);
+        let stack_size = PageSize::_2M.as_usize();
+
+        memory_space.alloc_and_map_area(MappingArea {
+            range: VirtualPageNumRange::from_start_count(
+                stack_base.to_floor_page_num(),
+                stack_size / PageSize::_4K.as_usize(),
+            ),
+            area_type: memory_space::AreaType::UserStack,
+            map_type: memory_space::MapType::Framed,
+            permissions: GenericMappingFlags::User
+                | GenericMappingFlags::Kernel
+                | GenericMappingFlags::Readable
+                | GenericMappingFlags::Writable,
+            allocation: None,
+        });
+
+        let loader = LinuxLoader {
+            memory_space,
+            entry_pc: VirtualAddress::from_usize(0x10000),
+            stack_top: stack_base + stack_size,
+            argv_base: VirtualAddress::null(),
+            envp_base: VirtualAddress::null(),
+            ctx,
+            executable: String::new(),
+        };
+
+        action(loader);
+    }
+
+    #[test]
+    fn test_stack_alignment() {
+        test_scene(ProcessContext::default(), |mut loader| {
+            let mut ctx = ProcessContext::new();
+            ctx.extend_argv(&[alloc::borrow::Cow::Borrowed("test")])
+                .unwrap();
+
+            let auxv_values = AuxVecValues {
+                random: Some([0u8; 16]),
+                platform: Some("test_platform"),
+            };
+
+            loader.init_stack(&ctx, &auxv_values).unwrap();
+
+            // Stack top should be aligned to 8
+            assert_eq!(
+                loader.stack_top.as_usize() % 8,
+                0,
+                "Stack top should be 8-byte aligned"
+            );
+
+            // Verify pointers alignment
+            assert_eq!(
+                loader.argv_base.as_usize() % 8,
+                0,
+                "argv_base should be 8-byte aligned"
+            );
+            assert_eq!(
+                loader.envp_base.as_usize() % 8,
+                0,
+                "envp_base should be 8-byte aligned"
+            );
+        });
+    }
+
+    #[test]
+    fn test_stack_layout_minimal() {
+        // Test minimal stack layout
+        test_scene(ProcessContext::default(), |mut loader| {
+            let ctx = ProcessContext::new();
+            let auxv_values = AuxVecValues::default();
+
+            loader.init_stack(&ctx, &auxv_values).unwrap();
+
+            let mmu = loader.memory_space.mmu().lock();
+            let mut stream = mmu.create_stream(loader.stack_top, false);
+
+            let argc: usize = *stream.read().unwrap();
+            assert_eq!(argc, 0);
+
+            let argv_null: VirtualAddress = *stream.read().unwrap();
+            assert!(argv_null.is_null());
+
+            let envp_null: VirtualAddress = *stream.read().unwrap();
+            assert!(envp_null.is_null());
+
+            let auxv_key: AuxVecKey = *stream.read().unwrap();
+            let auxv_value: usize = *stream.read().unwrap();
+            assert_eq!(auxv_key, AuxVecKey::AT_NULL);
+            assert_eq!(auxv_value, 0);
+        });
+    }
+
+    #[test]
+    fn test_stack_layout() {
+        use crate::auxv::{AuxVecKey, AuxVecValues};
+        use alloc::borrow::Cow;
+
+        test_scene(ProcessContext::default(), |mut loader| {
+            let mut ctx = ProcessContext::new();
+
+            ctx.extend_argv(&[
+                Cow::Borrowed("./test_program"),
+                Cow::Borrowed("arg1"),
+                Cow::Borrowed("arg2"),
+                Cow::Borrowed("hello world"),
+            ])
+            .unwrap();
+
+            ctx.extend_envp(&[
+                Cow::Borrowed("PATH=/usr/bin:/bin"),
+                Cow::Borrowed("HOME=/home/user"),
+                Cow::Borrowed("SHELL=/bin/bash"),
+                Cow::Borrowed("TEST_VAR=test_value"),
+            ])
+            .unwrap();
+
+            ctx.auxv.insert(AuxVecKey::AT_ENTRY, 0x400000);
+            ctx.auxv.insert(AuxVecKey::AT_PHDR, 0x400040);
+            ctx.auxv.insert(AuxVecKey::AT_PHENT, 56);
+            ctx.auxv.insert(AuxVecKey::AT_PHNUM, 9);
+            ctx.auxv.insert(AuxVecKey::AT_PAGESZ, 4096);
+            ctx.auxv.insert(AuxVecKey::AT_BASE, 0x7f0000000000);
+            ctx.auxv.insert(AuxVecKey::AT_FLAGS, 0);
+            ctx.auxv.insert(AuxVecKey::AT_UID, 1000);
+            ctx.auxv.insert(AuxVecKey::AT_EUID, 1000);
+            ctx.auxv.insert(AuxVecKey::AT_GID, 1000);
+            ctx.auxv.insert(AuxVecKey::AT_EGID, 1000);
+            ctx.auxv.insert(AuxVecKey::AT_SECURE, 0);
+            ctx.auxv.insert(AuxVecKey::AT_CLKTCK, 100);
+            ctx.auxv.insert(AuxVecKey::AT_HWCAP, 0x178bfbff);
+
+            let random_bytes = [
+                0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54,
+                0x32, 0x10,
+            ];
+            let auxv_values = AuxVecValues {
+                random: Some(random_bytes),
+                platform: Some("x86_64"),
+            };
+
+            loader.init_stack(&ctx, &auxv_values).unwrap();
+
+            verify_stack_layout(&loader, &ctx, &auxv_values);
+        });
+    }
+
+    // Verify that the stack layout matches the expected structure
+    fn verify_stack_layout(loader: &LinuxLoader, ctx: &ProcessContext, auxv_values: &AuxVecValues) {
+        let mmu = loader.memory_space.mmu().lock();
+        let mut stream = mmu.create_stream(loader.stack_top, false);
+
+        let argc: usize = *stream.read().unwrap();
+        assert_eq!(
+            argc,
+            ctx.argv.len(),
+            "argc should match the number of arguments"
+        );
+
+        let mut argv_pointers = Vec::new();
+        for i in 0..argc {
+            let ptr: VirtualAddress = *stream.read().unwrap();
+            argv_pointers.push(ptr);
+            assert!(!ptr.is_null(), "argv[{}] should not be null", i);
+        }
+
+        let argv_null: VirtualAddress = *stream.read().unwrap();
+        assert!(argv_null.is_null(), "argv array should be null-terminated");
+
+        let envp_pointers = stream
+            .read_unsized_slice::<VirtualAddress>(|ptr, _| !ptr.is_null())
+            .unwrap()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+
+        assert!(
+            stream.read::<VirtualAddress>().unwrap().is_null(),
+            "envp array should be null-terminated"
+        );
+
+        assert_eq!(
+            envp_pointers.len(),
+            ctx.envp.len(),
+            "envp count should match"
+        );
+
+        let mut auxv_entries = Vec::new();
+        loop {
+            let key: AuxVecKey = *stream.read().unwrap();
+            let value: usize = *stream.read().unwrap();
+
+            auxv_entries.push((key, value));
+            if key == AuxVecKey::AT_NULL {
+                break;
+            }
+        }
+
+        verify_common_auxv_entries(&auxv_entries, ctx);
+
+        verify_string_array_contents(&mut stream, &argv_pointers, &ctx.argv);
+        verify_string_array_contents(&mut stream, &envp_pointers, &ctx.envp);
+
+        verify_special_auxv_values(&mut stream, &auxv_entries, auxv_values);
+    }
+
+    fn verify_common_auxv_entries(auxv_entries: &[(AuxVecKey, usize)], _ctx: &ProcessContext) {
+        assert_eq!(auxv_entries.last().unwrap().0, AuxVecKey::AT_NULL);
+
+        let auxv_map: alloc::collections::BTreeMap<AuxVecKey, usize> =
+            auxv_entries.iter().copied().collect();
+
+        assert_eq!(auxv_map.get(&AuxVecKey::AT_ENTRY), Some(&0x400000));
+        assert_eq!(auxv_map.get(&AuxVecKey::AT_PHDR), Some(&0x400040));
+        assert_eq!(auxv_map.get(&AuxVecKey::AT_PAGESZ), Some(&4096));
+        assert_eq!(auxv_map.get(&AuxVecKey::AT_UID), Some(&1000));
+        assert_eq!(auxv_map.get(&AuxVecKey::AT_CLKTCK), Some(&100));
+    }
+
+    fn verify_string_array_contents(
+        stream: &mut MemoryStream,
+        pointers: &[VirtualAddress],
+        expected_strings: &[alloc::borrow::Cow<str>],
+    ) {
+        for (i, (ptr, expected)) in pointers.iter().zip(expected_strings.iter()).enumerate() {
+            stream.seek(Whence::Set(*ptr));
+            let bytes = stream.read_unsized_slice::<u8>(|&c, _| c != b'\0').unwrap();
+
+            let actual_string = core::str::from_utf8(bytes).unwrap();
+            assert_eq!(
+                actual_string,
+                expected.as_ref(),
+                "String at index {} should match",
+                i
+            );
+        }
+    }
+
+    fn verify_special_auxv_values(
+        stream: &mut MemoryStream,
+        auxv_entries: &[(AuxVecKey, usize)],
+        auxv_values: &AuxVecValues,
+    ) {
+        let auxv_map: alloc::collections::BTreeMap<AuxVecKey, usize> =
+            auxv_entries.iter().copied().collect();
+
+        if let Some(expected_random) = auxv_values.random {
+            let random = auxv_map.get(&AuxVecKey::AT_RANDOM).unwrap();
+            stream.seek(Whence::Set(VirtualAddress::from_usize(*random)));
+
+            let actual_random = *stream.read::<[u8; 16]>().unwrap();
+
+            assert_eq!(actual_random, expected_random);
+        }
+
+        if let Some(expected_platform) = auxv_values.platform {
+            let platform_addr = auxv_map.get(&AuxVecKey::AT_PLATFORM).unwrap();
+            stream.seek(Whence::Set(VirtualAddress::from_usize(*platform_addr)));
+
+            let actual_platform = stream.read_unsized_slice::<u8>(|&c, _| c != b'\0').unwrap();
+            let actual_platform = String::from_utf8_lossy(actual_platform);
+            assert_eq!(actual_platform, expected_platform,);
+        }
+    }
+}

--- a/libraries/stream/src/lib.rs
+++ b/libraries/stream/src/lib.rs
@@ -286,6 +286,7 @@ impl MemoryWindow {
     /// # Returns
     ///
     /// The new cursor position after skipping
+    #[inline]
     pub fn skip(&mut self, len: usize) -> VirtualAddress {
         self.seek(Whence::Offset(len as isize))
     }
@@ -299,6 +300,7 @@ impl MemoryWindow {
     /// # Returns
     ///
     /// The new cursor position after seeking
+    #[inline]
     pub fn seek(&mut self, whence: Whence) -> VirtualAddress {
         let target = match whence {
             Whence::Set(offset) => offset,

--- a/test-utilities/src/memory.rs
+++ b/test-utilities/src/memory.rs
@@ -378,7 +378,7 @@ impl IMMU for TestMMU {
                     // Sync the mapped memory to the physical memory
                     let slice = mapped.slice_mut();
 
-                    let _ = self.write_bytes(vaddr, slice);
+                    let _ = self.write_bytes(mapped.vaddr, slice);
                 }
             }
         }

--- a/test-utilities/src/memory.rs
+++ b/test-utilities/src/memory.rs
@@ -361,9 +361,10 @@ impl IMMU for TestMMU {
     fn unmap_buffer(&self, vaddr: VirtualAddress) {
         let mut locked = self.mapped.lock();
 
-        if let Some(mapped) = locked.get(&vaddr) {
+        if let Some((_, mapped)) = locked.iter().find(|(_, m)| m.range().contains(vaddr)) {
             if mapped.release() {
-                let mapped = locked.remove(&vaddr).unwrap();
+                let key = mapped.vaddr;
+                let mapped = locked.remove(&key).unwrap();
 
                 if mapped.mutable {
                     // Sync the mapped memory to the physical memory

--- a/test-utilities/src/memory.rs
+++ b/test-utilities/src/memory.rs
@@ -1,7 +1,11 @@
-use std::{alloc::Layout, collections::BTreeMap, sync::Arc};
+use std::{
+    alloc::Layout,
+    collections::BTreeMap,
+    sync::{atomic::AtomicUsize, Arc},
+};
 
 use abstractions::IUsizeAlias;
-use address::{IAlignableAddress, PhysicalAddress, VirtualAddress, VirtualAddressRange};
+use address::{IAddress, IAlignableAddress, PhysicalAddress, VirtualAddress, VirtualAddressRange};
 use hermit_sync::SpinMutex;
 use mmu_abstractions::{GenericMappingFlags, MMUError, PageSize, PagingError, PagingResult, IMMU};
 
@@ -308,8 +312,11 @@ impl IMMU for TestMMU {
         let mem = MappedMemory::alloc(vaddr, len, false);
         let mut mapped = self.mapped.lock();
 
-        if mapped.iter().any(|m| m.1.range().intersects(mem.range())) {
-            return Err(MMUError::Borrowed);
+        if let Some((_, mapped)) = mapped.iter().find(|m| m.1.range().intersects(mem.range())) {
+            let offset = vaddr.diff(mapped.range().start()) as usize;
+
+            mapped.add_ref();
+            return Ok(unsafe { core::slice::from_raw_parts(mapped.ptr.add(offset), len) });
         }
 
         let slice = mem.slice_mut();
@@ -329,8 +336,16 @@ impl IMMU for TestMMU {
         let mem = MappedMemory::alloc(vaddr, len, true);
         let mut mapped = self.mapped.lock();
 
-        if mapped.iter().any(|m| m.1.range().intersects(mem.range())) {
-            return Err(MMUError::Borrowed);
+        if let Some((_, mapped)) = mapped.iter().find(|m| m.1.range().intersects(mem.range())) {
+            if !mapped.mutable {
+                // FIXME: is this correct?
+                return Err(MMUError::Borrowed);
+            }
+
+            let offset = vaddr.diff(mapped.range().start()) as usize;
+            mapped.add_ref();
+
+            return Ok(unsafe { core::slice::from_raw_parts_mut(mapped.ptr.add(offset), len) });
         }
 
         let slice = mem.slice_mut();
@@ -346,13 +361,16 @@ impl IMMU for TestMMU {
     fn unmap_buffer(&self, vaddr: VirtualAddress) {
         let mut locked = self.mapped.lock();
 
-        if let Some(mapped) = locked.remove(&vaddr) {
-            // FIXME: ensuring RW rule for buffer mapping
-            if mapped.mutable {
-                // Sync the mapped memory to the physical memory
-                let slice = mapped.slice_mut();
+        if let Some(mapped) = locked.get(&vaddr) {
+            if mapped.release() {
+                let mapped = locked.remove(&vaddr).unwrap();
 
-                let _ = self.write_bytes(vaddr, slice);
+                if mapped.mutable {
+                    // Sync the mapped memory to the physical memory
+                    let slice = mapped.slice_mut();
+
+                    let _ = self.write_bytes(vaddr, slice);
+                }
             }
         }
     }
@@ -448,6 +466,7 @@ struct MappedMemory {
     ptr: *mut u8,
     layout: Layout,
     mutable: bool,
+    rc: AtomicUsize,
 }
 
 impl MappedMemory {
@@ -461,6 +480,7 @@ impl MappedMemory {
             ptr,
             layout,
             mutable,
+            rc: AtomicUsize::new(1),
         }
     }
 
@@ -470,6 +490,14 @@ impl MappedMemory {
 
     fn slice_mut(&self) -> &'static mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.layout.size()) }
+    }
+
+    fn add_ref(&self) {
+        self.rc.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn release(&self) -> bool {
+        self.rc.fetch_sub(1, std::sync::atomic::Ordering::Relaxed) == 1
     }
 }
 

--- a/test-utilities/src/memory.rs
+++ b/test-utilities/src/memory.rs
@@ -313,6 +313,12 @@ impl IMMU for TestMMU {
         let mut mapped = self.mapped.lock();
 
         if let Some((_, mapped)) = mapped.iter().find(|m| m.1.range().intersects(mem.range())) {
+            let expected_range = VirtualAddressRange::from_start_len(vaddr, len);
+
+            if !mapped.range().contains_range(expected_range) {
+                return Err(MMUError::Borrowed);
+            }
+
             let offset = vaddr.diff(mapped.range().start()) as usize;
 
             mapped.add_ref();
@@ -337,7 +343,9 @@ impl IMMU for TestMMU {
         let mut mapped = self.mapped.lock();
 
         if let Some((_, mapped)) = mapped.iter().find(|m| m.1.range().intersects(mem.range())) {
-            if !mapped.mutable {
+            let expected_range = VirtualAddressRange::from_start_len(vaddr, len);
+
+            if !mapped.mutable || !mapped.range().contains_range(expected_range) {
                 // FIXME: is this correct?
                 return Err(MMUError::Borrowed);
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster stack setup and memory operations via a new streaming write path and added inlining hints.

* **Reliability**
  * More robust argv/envp/auxv construction with improved alignment and cursor handling.
  * Test memory mappings now support shared mappings with reference counting to reduce mapping conflicts and improve concurrency.

* **Refactor**
  * Stack-writing logic consolidated into a streaming loader for clarity and maintainability.

* **Tests**
  * Added comprehensive tests for stack layout, alignment, and loader behavior.

* **Chores**
  * Added a new internal streaming dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->