### PR TITLE
[WIP] feat(linux-syscalls): implement `sys_execve` system call

### DIFF
--- a/linux-syscalls/Cargo.toml
+++ b/linux-syscalls/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 hermit-sync = "0.1.6"
+stream = { path = "../libraries/stream", default-features = false }
 utilities = { path = "../libraries/utilities", default-features = false }
 timing = { path = "../libraries/timing", default-features = false }
 abstractions = { path = "../libraries/abstractions", default-features = false }

--- a/linux-syscalls/src/sys_execve.rs
+++ b/linux-syscalls/src/sys_execve.rs
@@ -1,22 +1,73 @@
 use abstractions::IUsizeAlias;
-use address::VirtualAddress;
+use address::{IAddressBase, IAlignableAddress, VirtualAddress};
 use constants::ErrNo;
 use linux_loader::auxv::AuxVecValues;
 use linux_loader::{IExecSource, LinuxLoader, ProcessContext, RawMemorySpace};
 use platform_specific::ITaskContext;
 use platform_specific::TaskTrapContext;
+use stream::{IMMUStreamExt, MemoryStream};
 use task_abstractions::status::TaskStatus;
+use utilities::InvokeOnDrop;
 
 use crate::{SyscallContext, SyscallResult};
 
 impl SyscallContext {
+    const ARRAY_MAX_LEN: usize = 1024; // temporary value
+    const STRING_MAX_LEN: usize = 4096; // temporary value
+
+    /// The `execve` system call implementation.
+    /// This syscall build a new memory space wtih the given executable file,
+    /// initializing the new memory space's stack with the given arguments and environment variables,
+    /// and replace current process's memory space with the new one.
     pub fn sys_execve(
         &self,
-        _pathname: VirtualAddress,
-        _argv: VirtualAddress,
-        _envp: VirtualAddress,
+        pathname: VirtualAddress,
+        argv: VirtualAddress,
+        envp: VirtualAddress,
     ) -> SyscallResult {
-        todo!()
+        let process = self.task.linux_process();
+
+        let mmu = process.mmu();
+        let locked_mmu = mmu.lock();
+        let mut stream = locked_mmu.create_stream(VirtualAddress::null(), true);
+
+        let path = import_c_bytes(&mut stream, pathname, Self::STRING_MAX_LEN)?;
+        let path = core::str::from_utf8(path).map_err(|_| ErrNo::InvalidArgument)?;
+
+        let argv_pointers = import_c_ptr_array(&mut stream, argv, Self::ARRAY_MAX_LEN)?;
+        let argv_contents = import_c_bytes_array(&mut stream, argv_pointers, Self::STRING_MAX_LEN)?;
+
+        let envp_pointers = import_c_ptr_array(&mut stream, envp, Self::ARRAY_MAX_LEN)?;
+        let envp_contents = import_c_bytes_array(&mut stream, envp_pointers, Self::STRING_MAX_LEN)?;
+
+        core::mem::forget(stream); // prevent mapped buffer from being dropped and releasing borrow from mmu
+
+        // Free the buffers manually, this will be called when it was dropped
+        let _guard = InvokeOnDrop::new(|_| {
+            let free = |vaddr: VirtualAddress| locked_mmu.unmap_buffer(vaddr);
+            let free_array = |array: &[VirtualAddress]| {
+                for &vaddr in array {
+                    debug_assert!(!vaddr.is_null());
+
+                    free(vaddr);
+                }
+            };
+
+            free(pathname);
+            free_array(argv_pointers);
+            free_array(envp_pointers);
+            free(argv);
+            free(envp);
+        });
+
+        self.sys_execve_internal(
+            [0u8].as_slice(), // TODO
+            path,
+            &argv_contents,
+            &envp_contents,
+            // TODO: pass the locked mmu, since we can't unlock it until the execve is done
+            //otherwise the memory may be invalid due to modification to the memory space
+        )
     }
 
     /// Perform an execve-like replacement of the current task's address space with a new executable.
@@ -49,13 +100,12 @@ impl SyscallContext {
     /// // Given a `ctx: SyscallContext`, an executable `exe` and path:
     /// let _ = ctx.sys_execve_internal(exe, "/bin/app", &["app", "--help"], &[]);
     /// ```
-    #[expect(unused)]
     fn sys_execve_internal(
         &self,
         executable: impl IExecSource,
         pathname: &str,
-        argv: &[&str],
-        envp: &[&str],
+        _argv: &[&[u8]],
+        _envp: &[&[u8]],
     ) -> SyscallResult {
         let process = self.task.linux_process();
 
@@ -64,7 +114,7 @@ impl SyscallContext {
             (mem.mmu().clone(), mem.allocator().clone())
         };
 
-        let mut process_ctx = ProcessContext::new();
+        let process_ctx = ProcessContext::new();
 
         // FIXME: Pass argv, envp
 
@@ -102,3 +152,97 @@ impl SyscallContext {
         Ok(0)
     }
 }
+
+/// The Rust's borrow checker bind the lifetime with ownership
+/// This function promotes the lifetime to 'static to unbind ownership from the lifetime
+///
+/// # Safety
+/// The caller must ensure the slice is valid in the lifetime of the returned static slice.
+/// In our case, must be dropped before the mmu is unlocked.
+unsafe fn bump_slice_to_static<T>(val: &[T]) -> &'static [T] {
+    unsafe { core::slice::from_raw_parts(val.as_ptr(), val.len()) }
+}
+
+/// Import a C-style pointer array from given memory space via stream.
+fn import_c_ptr_array(
+    stream: &mut MemoryStream,
+    ptr: VirtualAddress,
+    max_len: usize,
+) -> Result<&'static [VirtualAddress], ErrNo> {
+    if !ptr.is_aligned(core::mem::align_of::<VirtualAddress>()) {
+        return Err(ErrNo::InvalidArgument);
+    }
+
+    let max_idx = max_len - 1;
+
+    stream.seek(stream::Whence::Set(ptr));
+
+    let mut read_complete = false;
+
+    let slice = stream
+        .read_unsized_slice::<VirtualAddress>(|ptr, idx| {
+            if ptr.is_null() {
+                read_complete = true;
+                return false;
+            }
+
+            idx < max_idx
+        })
+        .map_err(|_| ErrNo::BadAddress)?;
+
+    if !read_complete {
+        // TODO: too long
+        return Err(ErrNo::InvalidArgument);
+    }
+
+    Ok(unsafe { bump_slice_to_static(slice) })
+}
+
+/// Import a C-style bytes array from given memory space via stream.
+fn import_c_bytes(
+    stream: &mut MemoryStream,
+    ptr: VirtualAddress,
+    max_len: usize,
+) -> Result<&'static [u8], ErrNo> {
+    let max_idx = max_len - 1;
+
+    stream.seek(stream::Whence::Set(ptr));
+
+    let mut read_complete = false;
+    let slice = stream
+        .read_unsized_slice::<u8>(|byte, idx| {
+            if *byte == 0 {
+                read_complete = true;
+                return false;
+            }
+
+            idx < max_idx
+        })
+        .map_err(|_| ErrNo::BadAddress)?;
+
+    if !read_complete {
+        // TODO: too long
+        return Err(ErrNo::InvalidArgument);
+    }
+
+    Ok(unsafe { bump_slice_to_static(slice) })
+}
+
+/// Import an array of C-style bytes array from given memory space via stream.
+fn import_c_bytes_array(
+    stream: &mut MemoryStream,
+    array: &[VirtualAddress],
+    content_max_len: usize,
+) -> Result<Vec<&'static [u8]>, ErrNo> {
+    let mut result = Vec::with_capacity(array.len());
+
+    for &ptr in array {
+        let slice = import_c_bytes(stream, ptr, content_max_len)?;
+        result.push(slice);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {}


### PR DESCRIPTION
*work in progress*

- Introduce functionality to load arguments and environment variables for the `sys_execve` system call, enhancing process execution capabilities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled execve system call to launch new programs, with validation and parsing of path, arguments, and environment.
- Refactor
  - Improved syscall memory parsing for paths/argv/envp to enhance robustness and safety.
- Tests
  - Added initial test scaffolding for the execve flow.
- Chores
  - Added an internal dependency to support memory streaming; no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->