### PR TITLE
[BLOCK] refactor(address-v2): update address struct to use lifetime tracking

### DIFF
--- a/libraries/address-v2/src/addr_base.rs
+++ b/libraries/address-v2/src/addr_base.rs
@@ -30,7 +30,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl $type<'_> {
+        impl $type<'static> {
             /// Aligns the address down to the given alignment.
             ///
             /// # Examples
@@ -98,7 +98,9 @@ macro_rules! impl_addr {
                     (*self).is_multiple_of(align)
                 }
             }
+        }
 
+        impl $type<'_> {
             /// Returns the offset from the given alignment.
             ///
             /// # Examples
@@ -182,7 +184,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl const ::core::ops::Add<usize> for $type<'_> {
+        impl const ::core::ops::Add<usize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -192,7 +194,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl const ::core::ops::Add<isize> for $type<'_> {
+        impl const ::core::ops::Add<isize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -202,7 +204,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl const ::core::ops::Sub<usize> for $type<'_> {
+        impl const ::core::ops::Sub<usize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -212,7 +214,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl const ::core::ops::Sub<isize> for $type<'_> {
+        impl const ::core::ops::Sub<isize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -222,7 +224,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl const ::core::ops::Add<$type<'_>> for $type<'_> {
+        impl const ::core::ops::Add<$type<'static>> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -232,7 +234,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl const ::core::ops::Sub<$type<'_>> for $type<'_> {
+        impl const ::core::ops::Sub<$type<'static>> for $type<'static> {
             type Output = isize;
 
             #[inline(always)]
@@ -241,28 +243,28 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::AddAssign<usize> for $type<'_> {
+        impl ::core::ops::AddAssign<usize> for $type<'static> {
             #[inline(always)]
             fn add_assign(&mut self, rhs: usize) {
                 **self += rhs;
             }
         }
 
-        impl ::core::ops::AddAssign<isize> for $type<'_> {
+        impl ::core::ops::AddAssign<isize> for $type<'static> {
             #[inline(always)]
             fn add_assign(&mut self, rhs: isize) {
                 **self = (**self as isize + rhs) as usize;
             }
         }
 
-        impl ::core::ops::SubAssign<usize> for $type<'_> {
+        impl ::core::ops::SubAssign<usize> for $type<'static> {
             #[inline(always)]
             fn sub_assign(&mut self, rhs: usize) {
                 **self -= rhs;
             }
         }
 
-        impl ::core::ops::SubAssign<isize> for $type<'_> {
+        impl ::core::ops::SubAssign<isize> for $type<'static> {
             #[inline(always)]
             fn sub_assign(&mut self, rhs: isize) {
                 **self = (**self as isize - rhs) as usize;
@@ -270,7 +272,7 @@ macro_rules! impl_addr {
         }
 
         // Bitwise operations
-        impl ::core::ops::BitAnd<usize> for $type<'_> {
+        impl ::core::ops::BitAnd<usize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -280,7 +282,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::BitAnd<$type<'_>> for $type<'_> {
+        impl ::core::ops::BitAnd<$type<'static>> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -290,7 +292,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::BitOr<usize> for $type<'_> {
+        impl ::core::ops::BitOr<usize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -300,7 +302,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::BitOr<$type<'_>> for $type<'_> {
+        impl ::core::ops::BitOr<$type<'static>> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -310,7 +312,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::BitXor<usize> for $type<'_> {
+        impl ::core::ops::BitXor<usize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -320,7 +322,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::BitXor<$type<'_>> for $type<'_> {
+        impl ::core::ops::BitXor<$type<'static>> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -330,7 +332,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::Not for $type<'_> {
+        impl ::core::ops::Not for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -340,7 +342,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::Shl<usize> for $type<'_> {
+        impl ::core::ops::Shl<usize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -350,7 +352,7 @@ macro_rules! impl_addr {
             }
         }
 
-        impl ::core::ops::Shr<usize> for $type<'_> {
+        impl ::core::ops::Shr<usize> for $type<'static> {
             type Output = Self;
 
             #[inline(always)]
@@ -361,56 +363,56 @@ macro_rules! impl_addr {
         }
 
         // Bitwise assignment operations
-        impl ::core::ops::BitAndAssign<usize> for $type<'_> {
+        impl ::core::ops::BitAndAssign<usize> for $type<'static> {
             #[inline(always)]
             fn bitand_assign(&mut self, rhs: usize) {
                 **self &= rhs;
             }
         }
 
-        impl ::core::ops::BitAndAssign<$type<'_>> for $type<'_> {
+        impl ::core::ops::BitAndAssign<$type<'static>> for $type<'static> {
             #[inline(always)]
             fn bitand_assign(&mut self, rhs: $type) {
                 *self &= *rhs;
             }
         }
 
-        impl ::core::ops::BitOrAssign<usize> for $type<'_> {
+        impl ::core::ops::BitOrAssign<usize> for $type<'static> {
             #[inline(always)]
             fn bitor_assign(&mut self, rhs: usize) {
                 **self |= rhs;
             }
         }
 
-        impl ::core::ops::BitOrAssign<$type<'_>> for $type<'_> {
+        impl ::core::ops::BitOrAssign<$type<'static>> for $type<'static> {
             #[inline(always)]
             fn bitor_assign(&mut self, rhs: $type) {
                 *self |= *rhs;
             }
         }
 
-        impl ::core::ops::BitXorAssign<usize> for $type<'_> {
+        impl ::core::ops::BitXorAssign<usize> for $type<'static> {
             #[inline(always)]
             fn bitxor_assign(&mut self, rhs: usize) {
                 **self ^= rhs;
             }
         }
 
-        impl ::core::ops::BitXorAssign<$type<'_>> for $type<'_> {
+        impl ::core::ops::BitXorAssign<$type<'static>> for $type<'static> {
             #[inline(always)]
             fn bitxor_assign(&mut self, rhs: $type) {
                 *self ^= *rhs;
             }
         }
 
-        impl ::core::ops::ShlAssign<usize> for $type<'_> {
+        impl ::core::ops::ShlAssign<usize> for $type<'static> {
             #[inline(always)]
             fn shl_assign(&mut self, rhs: usize) {
                 **self <<= rhs;
             }
         }
 
-        impl ::core::ops::ShrAssign<usize> for $type<'_> {
+        impl ::core::ops::ShrAssign<usize> for $type<'static> {
             #[inline(always)]
             fn shr_assign(&mut self, rhs: usize) {
                 **self >>= rhs;

--- a/libraries/address-v2/src/addr_base.rs
+++ b/libraries/address-v2/src/addr_base.rs
@@ -30,16 +30,6 @@ macro_rules! impl_addr {
             }
         }
 
-        impl<'a> $type<'a> {
-            #[inline(always)]
-            pub const fn same_lifetime(&'a self, addr: usize) -> $type<'a> {
-                $type {
-                    _0: addr,
-                    _marker: self._marker,
-                }
-            }
-        }
-
         impl $type<'_> {
             /// Aligns the address down to the given alignment.
             ///

--- a/libraries/address-v2/src/addr_base.rs
+++ b/libraries/address-v2/src/addr_base.rs
@@ -33,7 +33,10 @@ macro_rules! impl_addr {
         impl<'a> $type<'a> {
             #[inline(always)]
             pub const fn same_lifetime(&'a self, addr: usize) -> $type<'a> {
-                $type::new(addr)
+                $type {
+                    _0: addr,
+                    _marker: self._marker,
+                }
             }
         }
 

--- a/libraries/address-v2/src/addr_range_base.rs
+++ b/libraries/address-v2/src/addr_range_base.rs
@@ -5,8 +5,8 @@ macro_rules! impl_range {
         #[repr(C)]
         #[derive(Clone, Copy, Eq)]
         pub struct $range_type {
-            start: $addr_type,
-            end: $addr_type,
+            start: $addr_type<'static>,
+            end: $addr_type<'static>,
         }
 
         impl ::core::fmt::Debug for $range_type {
@@ -32,7 +32,7 @@ macro_rules! impl_range {
             /// assert_eq!(range.len(), 0x1000);
             /// ```
             #[inline(always)]
-            pub const fn new(start: $addr_type, end: $addr_type) -> Self {
+            pub const fn new(start: $addr_type<'static>, end: $addr_type<'static>) -> Self {
                 // Use deref to access the inner usize value
                 debug_assert!(*start <= *end, "Range start must be <= end");
                 Self { start, end }
@@ -51,7 +51,7 @@ macro_rules! impl_range {
             /// assert_eq!(range.len(), 0x1000);
             /// ```
             #[inline(always)]
-            pub const unsafe fn new_unchecked(start: $addr_type, end: $addr_type) -> Self {
+            pub const unsafe fn new_unchecked(start: $addr_type<'static>, end: $addr_type<'static>) -> Self {
                 Self { start, end }
             }
 
@@ -65,19 +65,19 @@ macro_rules! impl_range {
             /// assert_eq!(range.end(), PhysAddr::new(0x2000));
             /// ```
             #[inline(always)]
-            pub const fn from_start_len(start: $addr_type, len: usize) -> Self {
+            pub const fn from_start_len(start: $addr_type<'static>, len: usize) -> Self {
                 Self::new(start, $addr_type::new(*start + len))
             }
 
             /// Returns the start address of the range.
             #[inline(always)]
-            pub const fn start(&self) -> $addr_type {
+            pub const fn start(&self) -> $addr_type<'static> {
                 self.start
             }
 
             /// Returns the end address of the range (exclusive).
             #[inline(always)]
-            pub const fn end(&self) -> $addr_type {
+            pub const fn end(&self) -> $addr_type<'static> {
                 self.end
             }
 
@@ -272,8 +272,8 @@ macro_rules! impl_range {
 
         /// Iterator over addresses in a range
         pub struct RangeIterator {
-            current: $addr_type,
-            end: $addr_type,
+            current: $addr_type<'static>,
+            end: $addr_type<'static>,
             step: usize,
         }
 
@@ -311,7 +311,7 @@ macro_rules! impl_range {
 
         impl ::core::iter::Iterator for RangeIterator
         {
-            type Item = $addr_type;
+            type Item = $addr_type<'static>;
 
             fn next(&mut self) -> Option<Self::Item> {
                 let new_current = *self.current + self.step;

--- a/libraries/address-v2/src/page_base.rs
+++ b/libraries/address-v2/src/page_base.rs
@@ -4,7 +4,7 @@ macro_rules! impl_page {
         #[repr(C)]
         #[derive(Clone, Copy, Eq)]
         pub struct $page_type {
-            addr: $addr_type,
+            addr: $addr_type<'static>,
             size: usize, // TODO: should we use a enum for common sizes?
         }
 
@@ -50,7 +50,7 @@ macro_rules! impl_page {
             /// assert!(unaligned.is_none());
             /// ```
             #[inline(always)]
-            pub const fn new_4k(addr: $addr_type) -> Option<Self> {
+            pub const fn new_4k(addr: $addr_type<'static>) -> Option<Self> {
                 Self::new_custom(addr, Self::SIZE_4K)
             }
 
@@ -75,7 +75,7 @@ macro_rules! impl_page {
             /// assert!(unaligned.is_none());
             /// ```
             #[inline(always)]
-            pub const fn new_2m(addr: $addr_type) -> Option<Self> {
+            pub const fn new_2m(addr: $addr_type<'static>) -> Option<Self> {
                 Self::new_custom(addr, Self::SIZE_2M)
 
             }
@@ -101,7 +101,7 @@ macro_rules! impl_page {
             /// assert!(unaligned.is_none());
             /// ```
             #[inline(always)]
-            pub const fn new_1g(addr: $addr_type) -> Option<Self> {
+            pub const fn new_1g(addr: $addr_type<'static>) -> Option<Self> {
                 Self::new_custom(addr, Self::SIZE_1G)
 
             }
@@ -135,7 +135,7 @@ macro_rules! impl_page {
             /// assert!(zero_size.is_none());
             /// ```
             #[inline(always)]
-            pub const fn new_custom(addr: $addr_type, size: usize) -> Option<Self> {
+            pub const fn new_custom(addr: $addr_type<'static>, size: usize) -> Option<Self> {
                 if size != 0 && addr.is_aligned(size) {
                     Some(Self { addr, size })
                 } else {
@@ -164,7 +164,7 @@ macro_rules! impl_page {
             /// assert_eq!(page.size(), 0x5678);
             /// ```
             #[inline(always)]
-            pub const fn new_custom_unchecked(addr: $addr_type, size: usize) -> Self {
+            pub const fn new_custom_unchecked(addr: $addr_type<'static>, size: usize) -> Self {
                 Self { addr, size }
             }
         }
@@ -182,7 +182,7 @@ macro_rules! impl_page {
             /// assert_eq!(page.addr(), PhysAddr::new(0x1000));
             /// ```
             #[inline(always)]
-            pub const fn addr(&self) -> $addr_type {
+            pub const fn addr(&self) -> $addr_type<'static> {
                 self.addr
             }
 

--- a/libraries/address-v2/src/virt_addr.rs
+++ b/libraries/address-v2/src/virt_addr.rs
@@ -43,6 +43,13 @@ impl<T: ?Sized> From<*const T> for VirtAddr<'static> {
     }
 }
 
+impl<T: ?Sized> From<*mut T> for VirtAddr<'static> {
+    #[inline(always)]
+    fn from(ptr: *mut T) -> Self {
+        VirtAddr::new(ptr as *mut () as usize)
+    }
+}
+
 impl<'a, T: ?Sized> From<&'a T> for VirtAddr<'a>
 where
     T: Deref,

--- a/libraries/address-v2/src/virt_addr.rs
+++ b/libraries/address-v2/src/virt_addr.rs
@@ -16,7 +16,7 @@ impl VirtAddr<'_> {
     /// A valid address not only requires to be non-null, but also must point to
     /// a properly mapped memory region in the **current** address space.
     #[inline(always)]
-    pub unsafe fn as_ptr<T>(self) -> *const T {
+    pub unsafe fn as_ptr<T: Sized>(self) -> *const T {
         *self as *const T
     }
 
@@ -31,12 +31,12 @@ impl VirtAddr<'_> {
     /// A valid address not only requires to be non-null, but also must point to
     /// a properly mapped memory region in the **current** address space.
     #[inline(always)]
-    pub unsafe fn as_mut_ptr<T>(self) -> *mut T {
+    pub unsafe fn as_mut_ptr<T: Sized>(self) -> *mut T {
         *self as *mut T
     }
 }
 
-impl<T> From<*const T> for VirtAddr<'static> {
+impl<T: ?Sized> From<*const T> for VirtAddr<'static> {
     #[inline(always)]
     fn from(ptr: *const T) -> Self {
         VirtAddr::new(ptr as *const () as usize)

--- a/libraries/address-v2/src/virt_addr.rs
+++ b/libraries/address-v2/src/virt_addr.rs
@@ -4,7 +4,7 @@ impl_addr!(VirtAddr,
     /// Represents a virtual address.
 );
 
-impl VirtAddr {
+impl VirtAddr<'_> {
     /// Returns the address as a raw pointer of type `*const T`.
     ///
     /// # Safety
@@ -17,7 +17,7 @@ impl VirtAddr {
     /// a properly mapped memory region in the **current** address space.
     #[inline(always)]
     pub unsafe fn as_ptr<T>(self) -> *const T {
-        self.0 as *const T
+        *self as *const T
     }
 
     /// Returns the address as a raw pointer of type `*mut T`.
@@ -32,32 +32,32 @@ impl VirtAddr {
     /// a properly mapped memory region in the **current** address space.
     #[inline(always)]
     pub unsafe fn as_mut_ptr<T>(self) -> *mut T {
-        self.0 as *mut T
+        *self as *mut T
     }
 }
 
-impl<T> From<*const T> for VirtAddr {
+impl<T> From<*const T> for VirtAddr<'static> {
     #[inline(always)]
     fn from(ptr: *const T) -> Self {
         VirtAddr::new(ptr as *const () as usize)
     }
 }
 
-impl<T: ?Sized> From<&T> for VirtAddr
+impl<'a, T: ?Sized> From<&'a T> for VirtAddr<'a>
 where
     T: Deref,
 {
     #[inline(always)]
-    default fn from(value: &T) -> Self {
+    default fn from(value: &'a T) -> Self {
         let inner = Deref::deref(value);
 
         inner.into()
     }
 }
 
-impl<T: ?Sized> From<&T> for VirtAddr {
+impl<'a, T: ?Sized> From<&'a T> for VirtAddr<'a> {
     #[inline(always)]
-    default fn from(value: &T) -> Self {
+    default fn from(value: &'a T) -> Self {
         VirtAddr::new(value as *const T as *const () as usize)
     }
 }


### PR DESCRIPTION
This pull request refactors the address type in `libraries/address-v2/src/addr_base.rs` to use a lifetime parameter and updates all related operations, trait implementations, and tests to work with the new structure. The primary goal is to enhance type safety and flexibility by introducing a lifetime parameter and utilizing `PhantomData`. Additionally, the address range type in `libraries/address-v2/src/addr_range_base.rs` is updated to use the new address type with a `'static` lifetime.

Adding lifetime parameters to the VirtAddr type does not affect existing code. VirtAddr instances constructed using `new` or `from::<*const T>` are now promoted to 'static lifetimes.

The changes in this PR primarily target the usage of `VirtAddr::from<&T>`, adding lifetime parameters to `VirtAddr` instances created via references. This further ensures that unit tests(we don't always write required memory to the user space and then use user-space pointers) using `VirtAddr` safely utilize references as parameters. For example, code like this will no longer compile (and no way to make it compile can be found), because the reference lifetime used to construct the `VirtAddr` expires, rendering the `VirtAddr` invalid:

```rust
let vaddr: VirtAddr = {
    let x = 42;
    (&x).into() // compile error
};
```

*Waiting for more reviews to determine whether to merge this PR.*

### Address type refactor and API changes

* Refactored the address type from a simple `pub struct $type(usize)` to `pub struct $type<'a> { _0: usize, _marker: PhantomData<&'a ()> }`, introducing a lifetime parameter for improved type safety. Added a new `same_lifetime` method and updated all trait implementations to use the new structure.
* Updated all arithmetic, bitwise, and assignment operator trait implementations to work with the new lifetime-based address type, using dereferencing (`*self`, `**self`) for operations.
* Changed alignment-related methods (`align_down`, `align_up`, `is_aligned`, `offset_from_alignment`) to operate on the new address type and use dereferencing for calculations. 

### Test and usage updates

* Updated all test assertions and examples to use dereferencing (`*addr`) instead of accessing the old `.0` field, ensuring compatibility with the new address type structure. 

### Address range type update

* Changed the address range type fields to use `$addr_type<'static>` instead of the previous `$addr_type`, ensuring consistency with the new lifetime-based address type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address and virtual-address types are lifetime-aware; added helpers to preserve or promote lifetimes and lifetime-aware pointer conversions.

* **Refactor**
  * Range iterators and page APIs now use addresses with a 'static lifetime.
  * Public APIs tightened to explicit lifetimes; constructors, conversions, alignment, arithmetic, formatting, and comparisons updated to lifetime-aware dereferencing semantics.

* **Tests**
  * Tests updated/added for lifetime-aware construction, dereferencing, pointer conversions, and lifetime helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->