### PR TITLE
feat(utilities): add `invoke_on_drop!` macro for simplified guard creation

### DIFF
--- a/libraries/utilities/src/invoke_on_drop.rs
+++ b/libraries/utilities/src/invoke_on_drop.rs
@@ -98,17 +98,23 @@ use core::{
 /// ```
 #[macro_export]
 macro_rules! invoke_on_drop {
-    ($(#[$attr:meta])* || $body:expr) => {{
+    ($(#[$attr:meta])* || $body:block) => {{
         $crate::InvokeOnDrop::new(
             $(#[$attr])*
             #[inline(always)]
             |_| $body,
         )
     }};
-    ($val:expr, $(#[$attr:meta])* $func:expr) => {{
+    ($(#[$attr:meta])* move || $body:block) => {{
+        $crate::InvokeOnDrop::new(
+            $(#[$attr])*
+            #[inline(always)]
+            move |_| $body,
+        )
+    }};
+    ($val:expr, $func:expr) => {{
         $crate::InvokeOnDrop::transform(
             $val,
-            $(#[$attr])*
             #[inline(always)]
             $func,
         )

--- a/libraries/utilities/src/invoke_on_drop.rs
+++ b/libraries/utilities/src/invoke_on_drop.rs
@@ -70,6 +70,51 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
+/// Creates a new [`InvokeOnDrop`] guard that invokes the provided closure when dropped.
+///
+/// This macro is recommended over calling [`InvokeOnDrop::new`] or [`InvokeOnDrop::transform`] directly,
+/// as it ensures the closure is always inlined, preventing potential performance overhead.
+///
+/// # Returns
+///
+/// Returns a new [`InvokeOnDrop`] guard instance.
+///
+/// # Examples
+/// ```
+/// # use utilities::invoke_on_drop;
+/// // Create a guard that invokes a closure when dropped
+/// let _guard = invoke_on_drop!(|| {
+///     println!("Cleanup executed!");
+/// });
+///
+/// // Wrap a owned value and invoke a closure with it when dropped
+/// let value = String::from("Hello, world!");
+/// let guard = invoke_on_drop!(value, |val| {
+///    println!("Cleaning up value: {}", val);
+/// });
+///
+/// // `InvokeOnDrop` implements `Deref`, so you can access the inner value directly
+/// println!("Guarded value: {}", &*guard);
+/// ```
+#[macro_export]
+macro_rules! invoke_on_drop {
+    ($(#[$attr:meta])* || $body:expr) => {{
+        $crate::InvokeOnDrop::new(
+            $(#[$attr])*
+            #[inline(always)]
+            |_| $body,
+        )
+    }};
+    ($val:expr, $(#[$attr:meta])* $func:expr) => {{
+        $crate::InvokeOnDrop::transform(
+            $val,
+            $(#[$attr])*
+            #[inline(always)]
+            $func,
+        )
+    }};
+}
+
 /// A RAII guard that automatically invokes a closure when dropped.
 ///
 /// `InvokeOnDrop` provides a way to ensure that cleanup code is executed when a value
@@ -374,14 +419,12 @@ mod tests {
     use core::hint::black_box;
     use std::sync::{Arc, Mutex};
 
-    use super::*;
-
     #[test]
     fn test_drop_invoked() {
         let flag = Arc::new(Mutex::new(false));
 
         {
-            let _called = InvokeOnDrop::new(|_| {
+            let _called = invoke_on_drop!(|| {
                 *flag.lock().unwrap() = true;
             });
 
@@ -396,7 +439,7 @@ mod tests {
         let flag = Arc::new(Mutex::new(false));
 
         // Bind to a local so Drop doesn't run before the assertion
-        let _unused = InvokeOnDrop::new(|_| {
+        let _unused = invoke_on_drop!(|| {
             *flag.lock().unwrap() = true;
         });
 
@@ -405,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_transform() {
-        let i = InvokeOnDrop::transform(42, |i| {
+        let i = invoke_on_drop!(42, |i| {
             assert_eq!(i, 42);
         });
 
@@ -415,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_deref() {
-        let mut i = InvokeOnDrop::transform(42, |i| {
+        let mut i = invoke_on_drop!(42, |i| {
             assert_eq!(i, 24);
         });
 
@@ -431,7 +474,7 @@ mod tests {
         let x = Arc::new(());
 
         let cloned = x.clone();
-        let guard = InvokeOnDrop::new(|_| {
+        let guard = invoke_on_drop!(|| {
             black_box(cloned);
         });
 


### PR DESCRIPTION
This pull request adds a new macro to simplify and optimize the creation of RAII guards for cleanup actions in Rust, and updates existing code to use this macro for improved clarity and performance. The most important changes are grouped below:

### Macro introduction and documentation

* Added the `invoke_on_drop!` macro to `libraries/utilities/src/invoke_on_drop.rs`, allowing users to easily create `InvokeOnDrop` guards with closures that are always inlined for better performance. Comprehensive documentation and usage examples were included.

### Test code modernization

* Refactored tests to use the new `invoke_on_drop!` macro instead of directly calling `InvokeOnDrop::new`, demonstrating the macro's usage and improving test clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public invoke_on_drop macro for concise creation of scope-drop callbacks, supporting closure-only and value+closure forms; closures are inlined for performance.
- **Tests**
  - Updated tests to use and validate the new macro.
- **Documentation**
  - Added docs describing macro usage and inlining behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->