### PR TITLE
feat(runtime): add methods to access linear mapping window

### DIFF
--- a/libraries/runtime/src/baremetal/arch/riscv64/mod.rs
+++ b/libraries/runtime/src/baremetal/arch/riscv64/mod.rs
@@ -8,3 +8,4 @@ pub mod serial;
 mod boot;
 
 pub(crate) mod cpu;
+pub(crate) mod vm;

--- a/libraries/runtime/src/baremetal/arch/riscv64/vm.rs
+++ b/libraries/runtime/src/baremetal/arch/riscv64/vm.rs
@@ -1,0 +1,16 @@
+use core::ops::Range;
+
+/// Linear mapping window for physical memory
+pub const LINEAR_WINDOW: Range<usize> = 0xffff_ffc0_0000_0000..usize::MAX; // TODO: use a more reasonable upper bound
+
+/// Check if a virtual address is within the linear mapping window
+pub const fn is_linear_window(vaddr: usize) -> bool {
+    LINEAR_WINDOW.start <= vaddr && vaddr < LINEAR_WINDOW.end
+}
+
+/// Get the corresponding virtual address in the linear mapping window for a given physical address
+pub const fn get_linear_vaddr(paddr: usize) -> usize {
+    debug_assert!(!is_linear_window(paddr));
+
+    paddr + LINEAR_WINDOW.start
+}

--- a/libraries/runtime/src/baremetal/mod.rs
+++ b/libraries/runtime/src/baremetal/mod.rs
@@ -7,6 +7,11 @@ mod panic;
 #[cfg(target_os = "none")]
 mod serial;
 
+#[cfg(target_os = "none")]
+pub mod vm {
+    pub use super::arch::current::vm::*;
+}
+
 #[cfg(feature = "boot")]
 pub(crate) mod bss;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VM utilities for bare‑metal RISC‑V targets: a linear virtual address window and helpers to test addresses and compute corresponding linear virtual addresses.
  * Exposed these utilities via a new bare‑metal VM module, making them available to consumers targeting environments without an OS.
  * No behavioral changes for existing users; enhances low‑level memory handling for RISC‑V builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->