### PR TITLE
refactor: Use `Ikernel` for mmu creation and remove `ITestFrameAllocator`

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -42,7 +42,7 @@ impl IKernel for Kernel {
         todo!()
     }
 
-    fn allocator(&self) -> Arc<SpinMutex<dyn IFrameAllocator>> {
+    fn global_frame_alloc(&self) -> Arc<SpinMutex<dyn IFrameAllocator>> {
         self.allocator.clone()
     }
 

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -7,6 +7,7 @@ use kernel_abstractions::{IKernel, IKernelSerial};
 use linux_syscalls::SyscallContext;
 use linux_task_abstractions::ILinuxTask;
 use mmu_abstractions::IMMU;
+use mmu_native::PageTable;
 use timing::TimeSpec;
 
 use crate::serial::KernelSerial;
@@ -52,5 +53,12 @@ impl IKernel for Kernel {
 
     fn time(&self) -> TimeSpec {
         todo!()
+    }
+
+    fn create_mmu(
+        &self,
+        alloc: Option<Arc<SpinMutex<dyn IFrameAllocator>>>,
+    ) -> Arc<SpinMutex<dyn IMMU>> {
+        Arc::new(SpinMutex::new(PageTable::alloc(alloc.unwrap())))
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -106,8 +106,7 @@ static ELF: &[u8] = include_bytes!("../../hello-world/hello-la");
 static ELF: &[u8] = include_bytes!("../../hello-world/hello-rv");
 
 fn create_task(kernel: &Kernel) -> Arc<dyn ILinuxTask> {
-    let mmu: Arc<SpinMutex<dyn IMMU>> =
-        Arc::new(SpinMutex::new(PageTable::alloc(kernel.allocator())));
+    let mmu = kernel.create_mmu(Some(kernel.global_frame_alloc()));
 
     let ctx = ProcessContext::new();
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -16,8 +16,6 @@ use linux_loader::{LinuxLoader, ProcessContext, RawMemorySpace};
 use linux_syscalls::{ISyscallResult, SyscallContext};
 use linux_task::LinuxProcess;
 use linux_task_abstractions::ILinuxTask;
-use mmu_abstractions::IMMU;
-use mmu_native::PageTable;
 use platform_abstractions::{return_to_user, UserInterrupt};
 use platform_specific::{legacy_println, virt_to_phys, SyscallPayload};
 use task_abstractions::ITask;
@@ -110,7 +108,8 @@ fn create_task(kernel: &Kernel) -> Arc<dyn ILinuxTask> {
 
     let ctx = ProcessContext::new();
 
-    let memory_space: RawMemorySpace = (mmu, kernel.allocator());
+    let alloc = mmu.lock().bound_alloc().unwrap();
+    let memory_space: RawMemorySpace = (mmu, alloc);
 
     let loader = LinuxLoader::from_elf(&ELF, "", ctx, &memory_space).unwrap();
 

--- a/libraries/allocation-abstractions/src/lib.rs
+++ b/libraries/allocation-abstractions/src/lib.rs
@@ -39,6 +39,11 @@ pub trait IFrameAllocator {
     /// - The return value is `None` if the physical address is not in the linear mapping window.
     ///   Or if the frame allocator is not responsible for the linear mapping. This method is
     ///   intended to provide a backend option for MMU.
+    ///
+    /// # Safety
+    ///
+    /// The returned slice is static, caller must ensure that the slice is not used after the memory is deallocated.
+    /// This can be done by ensuring that the frame allocator outlives all usage of the slice.
     #[allow(clippy::mut_from_ref)]
-    fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]>;
+    unsafe fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]>;
 }

--- a/libraries/allocation-abstractions/src/lib.rs
+++ b/libraries/allocation-abstractions/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use address::PhysAddrRange;
 use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
@@ -21,4 +22,8 @@ pub trait IFrameAllocator {
     fn dealloc(&mut self, frame: FrameDesc);
 
     fn dealloc_range(&mut self, range: FrameRangeDesc);
+
+    fn check_paddr(&self, paddr: PhysAddrRange) -> bool;
+
+    unsafe fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]>;
 }

--- a/libraries/allocation-abstractions/src/lib.rs
+++ b/libraries/allocation-abstractions/src/lib.rs
@@ -39,9 +39,6 @@ pub trait IFrameAllocator {
     /// - The return value is `None` if the physical address is not in the linear mapping window.
     ///   Or if the frame allocator is not responsible for the linear mapping. This method is
     ///   intended to provide a backend option for MMU.
-    ///
-    /// # Safety
-    ///
-    /// Access raw memory may be dangerous, so use it with caution.
-    unsafe fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]>;
+    #[allow(clippy::mut_from_ref)]
+    fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]>;
 }

--- a/libraries/allocation-abstractions/src/lib.rs
+++ b/libraries/allocation-abstractions/src/lib.rs
@@ -25,5 +25,23 @@ pub trait IFrameAllocator {
 
     fn check_paddr(&self, paddr: PhysAddrRange) -> bool;
 
+    /// Try to get a slice of the physical address in the linear mapping window.
+    ///
+    /// The slice is guaranteed to be contiguous.
+    ///
+    /// # Parameters
+    ///
+    /// - `paddr`: The physical address range you want to access.
+    ///
+    /// # Returns
+    ///
+    /// - The raw memory slice to the physical address range in the linear mapping window.
+    /// - The return value is `None` if the physical address is not in the linear mapping window.
+    ///   Or if the frame allocator is not responsible for the linear mapping. This method is
+    ///   intended to provide a backend option for MMU.
+    ///
+    /// # Safety
+    ///
+    /// Access raw memory may be dangerous, so use it with caution.
     unsafe fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]>;
 }

--- a/libraries/allocation/src/lib.rs
+++ b/libraries/allocation/src/lib.rs
@@ -141,7 +141,7 @@ impl IFrameAllocator for FrameAllocator {
         core::mem::forget(range);
     }
 
-    unsafe fn linear_map(&self, _paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
+    fn linear_map(&self, _paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
         None // Native frame allocator cannot provide linear mapping
     }
 

--- a/libraries/allocation/src/lib.rs
+++ b/libraries/allocation/src/lib.rs
@@ -140,4 +140,12 @@ impl IFrameAllocator for FrameAllocator {
 
         core::mem::forget(range);
     }
+
+    unsafe fn linear_map(&self, _paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
+        None // Native frame allocator cannot provide linear mapping
+    }
+
+    fn check_paddr(&self, paddr: address::PhysAddrRange) -> bool {
+        paddr.start() >= self.bottom && paddr.end() <= self.top
+    }
 }

--- a/libraries/allocation/src/lib.rs
+++ b/libraries/allocation/src/lib.rs
@@ -141,7 +141,7 @@ impl IFrameAllocator for FrameAllocator {
         core::mem::forget(range);
     }
 
-    fn linear_map(&self, _paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
+    unsafe fn linear_map(&self, _paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
         None // Native frame allocator cannot provide linear mapping
     }
 

--- a/libraries/kernel-abstractions/src/lib.rs
+++ b/libraries/kernel-abstractions/src/lib.rs
@@ -25,6 +25,11 @@ pub trait IKernel: Downcast {
     fn activate_mmu(&self, pt: &dyn IMMU);
 
     fn time(&self) -> TimeSpec;
+
+    fn create_mmu(
+        &self,
+        alloc: Option<Arc<SpinMutex<dyn IFrameAllocator>>>,
+    ) -> Arc<SpinMutex<dyn IMMU>>;
 }
 
 impl_downcast!(IKernel);

--- a/libraries/kernel-abstractions/src/lib.rs
+++ b/libraries/kernel-abstractions/src/lib.rs
@@ -20,7 +20,7 @@ pub trait IKernel: Downcast {
 
     fn fs(&self) -> Arc<SpinMutex<Arc<DirectoryTreeNode>>>;
 
-    fn allocator(&self) -> Arc<SpinMutex<dyn IFrameAllocator>>;
+    fn global_frame_alloc(&self) -> Arc<SpinMutex<dyn IFrameAllocator>>;
 
     fn activate_mmu(&self, pt: &dyn IMMU);
 

--- a/libraries/linux-loader/src/elf.rs
+++ b/libraries/linux-loader/src/elf.rs
@@ -73,7 +73,7 @@ impl<'a> LinuxLoader<'a> {
             let pt = mmu.lock();
 
             let slice = pt
-                .translate_phys(
+                .linear_map_phys(
                     boxed_elf_holding.start().addr(),
                     boxed_elf_holding.as_addr_range().len(),
                 )

--- a/libraries/mmu-abstractions/Cargo.toml
+++ b/libraries/mmu-abstractions/Cargo.toml
@@ -13,6 +13,8 @@ doctest = false
 bitflags = "2.9"
 downcast-rs = { version = "2.0", default-features = false, features = ["sync"] }
 address = { path = "../address", default-features = false }
+allocation-abstractions = { path = "../allocation-abstractions" }
+hermit-sync = "0.1.6"
 
 [features]
 default = ["no_std"]

--- a/libraries/mmu-abstractions/src/lib.rs
+++ b/libraries/mmu-abstractions/src/lib.rs
@@ -11,8 +11,11 @@ extern crate alloc;
 
 mod flags;
 
+use alloc::sync::Arc;
+use allocation_abstractions::IFrameAllocator;
 use downcast_rs::{impl_downcast, Downcast};
 pub use flags::GenericMappingFlags;
+use hermit_sync::SpinMutex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MMUError {
@@ -103,6 +106,8 @@ impl dyn IMMU {
 }
 
 pub trait IMMU: Downcast {
+    fn bound_alloc(&self) -> Option<Arc<SpinMutex<dyn IFrameAllocator>>>;
+
     fn map_single(
         &mut self,
         vaddr: VirtAddr,

--- a/libraries/mmu-abstractions/src/lib.rs
+++ b/libraries/mmu-abstractions/src/lib.rs
@@ -154,7 +154,7 @@ pub trait IMMU: Downcast {
         callback: &mut dyn FnMut(&mut [u8], usize) -> bool,
     ) -> Result<(), MMUError>;
 
-    fn translate_phys(&self, paddr: PhysAddr, len: usize) -> Result<&'static mut [u8], MMUError>;
+    fn linear_map_phys(&self, paddr: PhysAddr, len: usize) -> Result<&'static mut [u8], MMUError>;
 
     fn read_bytes(&self, vaddr: VirtAddr, buf: &mut [u8]) -> Result<(), MMUError>;
 

--- a/libraries/mmu-native/src/pt.rs
+++ b/libraries/mmu-native/src/pt.rs
@@ -324,7 +324,7 @@ impl<Arch: IPageTableArchAttribute + 'static, PTE: IArchPageTableEntry + 'static
         Ok(())
     }
 
-    fn translate_phys(&self, paddr: PhysAddr, len: usize) -> Result<&'static mut [u8], MMUError> {
+    fn linear_map_phys(&self, paddr: PhysAddr, len: usize) -> Result<&'static mut [u8], MMUError> {
         let virt = get_linear_vaddr(*paddr) as *mut u8;
 
         Ok(unsafe { core::slice::from_raw_parts_mut(virt, len) })

--- a/libraries/mmu-native/src/pt.rs
+++ b/libraries/mmu-native/src/pt.rs
@@ -494,6 +494,10 @@ impl<Arch: IPageTableArchAttribute + 'static, PTE: IArchPageTableEntry + 'static
             self.unmap_single(window.vaddr).ok();
         }
     }
+
+    fn bound_alloc(&self) -> Option<Arc<SpinMutex<dyn IFrameAllocator>>> {
+        self.allocation.as_ref().map(|a| a.allocator.clone())
+    }
 }
 
 impl<Arch: IPageTableArchAttribute + 'static, PTE: IArchPageTableEntry + 'static>

--- a/libraries/mmu-native/src/pt.rs
+++ b/libraries/mmu-native/src/pt.rs
@@ -477,7 +477,10 @@ impl<Arch: IPageTableArchAttribute + 'static, PTE: IArchPageTableEntry + 'static
                 }
 
                 return Ok(unsafe {
-                    core::slice::from_raw_parts_mut(vaddr.as_mut_ptr::<u8>().add(page_offset), len)
+                    core::slice::from_raw_parts_mut(
+                        vaddr.as_mut_ptr::<u8>().add(slice_offset.unwrap()),
+                        len,
+                    )
                 });
             }
 

--- a/test-utilities/Cargo.toml
+++ b/test-utilities/Cargo.toml
@@ -22,7 +22,6 @@ task-abstractions = { path = "../libraries/task-abstractions", default-features 
 trap-abstractions = { path = "../libraries/trap-abstractions", default-features = false }
 allocation = { path = "../libraries/allocation", default-features = false }
 platform-specific = { path = "../libraries/platform-specific", default-features = false }
-libc = "0.2.174"
 
 [features]
 default = ["test_log"]

--- a/test-utilities/src/allocation/contiguous.rs
+++ b/test-utilities/src/allocation/contiguous.rs
@@ -75,7 +75,7 @@ impl IFrameAllocator for TestFrameAllocator {
         self.inner.bottom().addr() <= paddr.start() && paddr.end() <= self.inner.top().addr()
     }
 
-    fn linear_map(&self, paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
+    unsafe fn linear_map(&self, paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
         if !paddr.start().is_null() && self.check_paddr(paddr) {
             Some(unsafe { std::slice::from_raw_parts_mut(*paddr.start() as *mut u8, paddr.len()) })
         } else {

--- a/test-utilities/src/allocation/contiguous.rs
+++ b/test-utilities/src/allocation/contiguous.rs
@@ -75,7 +75,7 @@ impl IFrameAllocator for TestFrameAllocator {
         self.inner.bottom().addr() <= paddr.start() && paddr.end() <= self.inner.top().addr()
     }
 
-    unsafe fn linear_map(&self, paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
+    fn linear_map(&self, paddr: address::PhysAddrRange) -> Option<&'static mut [u8]> {
         if !paddr.start().is_null() && self.check_paddr(paddr) {
             Some(unsafe { std::slice::from_raw_parts_mut(*paddr.start() as *mut u8, paddr.len()) })
         } else {

--- a/test-utilities/src/allocation/mod.rs
+++ b/test-utilities/src/allocation/mod.rs
@@ -1,11 +1,2 @@
-use address::PhysAddr;
-use allocation_abstractions::IFrameAllocator;
-
 pub mod contiguous;
 pub mod segment;
-
-pub trait ITestFrameAllocator: IFrameAllocator {
-    fn check_paddr(&self, paddr: PhysAddr, len: usize) -> bool;
-
-    fn linear_map(&self, paddr: PhysAddr) -> Option<*mut u8>;
-}

--- a/test-utilities/src/allocation/segment.rs
+++ b/test-utilities/src/allocation/segment.rs
@@ -117,7 +117,7 @@ impl IFrameAllocator for TestFrameAllocator {
         false
     }
 
-    fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]> {
+    unsafe fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]> {
         if self.check_paddr(paddr) {
             unsafe {
                 Some(std::slice::from_raw_parts_mut(

--- a/test-utilities/src/allocation/segment.rs
+++ b/test-utilities/src/allocation/segment.rs
@@ -117,12 +117,14 @@ impl IFrameAllocator for TestFrameAllocator {
         false
     }
 
-    unsafe fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]> {
+    fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]> {
         if self.check_paddr(paddr) {
-            Some(std::slice::from_raw_parts_mut(
-                *paddr.start() as *mut u8,
-                paddr.len(),
-            ))
+            unsafe {
+                Some(std::slice::from_raw_parts_mut(
+                    *paddr.start() as *mut u8,
+                    paddr.len(),
+                ))
+            }
         } else {
             None
         }

--- a/test-utilities/src/allocation/segment.rs
+++ b/test-utilities/src/allocation/segment.rs
@@ -6,7 +6,7 @@ use allocation_abstractions::{FrameDesc, FrameRangeDesc, IFrameAllocator};
 use hermit_sync::SpinMutex;
 use mmu_abstractions::IMMU;
 
-use crate::{allocation::ITestFrameAllocator, memory::TestMMU};
+use crate::memory::TestMMU;
 
 pub struct TestFrameAllocator {
     records: BTreeMap<PhysAddr, HostMemory>,
@@ -32,26 +32,6 @@ impl TestFrameAllocator {
         }));
 
         (alloc.clone(), TestMMU::new(alloc))
-    }
-}
-
-impl ITestFrameAllocator for TestFrameAllocator {
-    fn check_paddr(&self, paddr: PhysAddr, len: usize) -> bool {
-        let range = PhysAddrRange::from_start_len(paddr, len);
-
-        for mem in self.records.values() {
-            let target_range = mem.paddr_range();
-
-            if target_range.intersects(range) {
-                return true;
-            }
-        }
-
-        false
-    }
-
-    fn linear_map(&self, _: PhysAddr) -> Option<*mut u8> {
-        None
     }
 }
 
@@ -123,6 +103,29 @@ impl IFrameAllocator for TestFrameAllocator {
     fn dealloc_range(&mut self, range: allocation_abstractions::FrameRangeDesc) {
         self.records.remove(&range.start().addr());
         core::mem::forget(range);
+    }
+
+    fn check_paddr(&self, paddr: PhysAddrRange) -> bool {
+        for mem in self.records.values() {
+            let target_range = mem.paddr_range();
+
+            if target_range.contains(paddr) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    unsafe fn linear_map(&self, paddr: PhysAddrRange) -> Option<&'static mut [u8]> {
+        if self.check_paddr(paddr) {
+            Some(std::slice::from_raw_parts_mut(
+                *paddr.start() as *mut u8,
+                paddr.len(),
+            ))
+        } else {
+            None
+        }
     }
 }
 

--- a/test-utilities/src/kernel.rs
+++ b/test-utilities/src/kernel.rs
@@ -66,7 +66,7 @@ impl IKernel for TestKernel {
         self.fs.as_ref().unwrap().clone()
     }
 
-    fn allocator(&self) -> Arc<SpinMutex<dyn IFrameAllocator>> {
+    fn global_frame_alloc(&self) -> Arc<SpinMutex<dyn IFrameAllocator>> {
         self.allocator.as_ref().unwrap().clone()
     }
 

--- a/test-utilities/src/kernel.rs
+++ b/test-utilities/src/kernel.rs
@@ -2,6 +2,7 @@ use allocation_abstractions::IFrameAllocator;
 use filesystem_abstractions::DirectoryTreeNode;
 use hermit_sync::SpinMutex;
 use kernel_abstractions::{IKernel, IKernelSerial};
+use mmu_abstractions::IMMU;
 use std::{
     collections::vec_deque::VecDeque,
     sync::Arc,
@@ -9,6 +10,8 @@ use std::{
     vec::Vec,
 };
 use timing::TimeSpec;
+
+use crate::memory::TestMMU;
 
 pub struct TestKernel {
     pub serial: Option<Arc<dyn IKernelSerial>>,
@@ -67,7 +70,14 @@ impl IKernel for TestKernel {
         self.allocator.as_ref().unwrap().clone()
     }
 
-    fn activate_mmu(&self, _pt: &dyn mmu_abstractions::IMMU) {}
+    fn activate_mmu(&self, _pt: &dyn IMMU) {}
+
+    fn create_mmu(
+        &self,
+        alloc: Option<Arc<SpinMutex<dyn IFrameAllocator>>>,
+    ) -> Arc<SpinMutex<dyn IMMU>> {
+        TestMMU::new(alloc.expect("Corresponding allocator must be provided"))
+    }
 
     fn time(&self) -> TimeSpec {
         let now = SystemTime::now();

--- a/test-utilities/src/memory.rs
+++ b/test-utilities/src/memory.rs
@@ -425,6 +425,10 @@ impl IMMU for TestMMU {
 
         source.unmap_buffer(vaddr);
     }
+
+    fn bound_alloc(&self) -> Option<Arc<SpinMutex<dyn IFrameAllocator>>> {
+        Some(self.alloc.clone())
+    }
 }
 
 impl TestMMU {

--- a/test-utilities/src/memory.rs
+++ b/test-utilities/src/memory.rs
@@ -276,13 +276,11 @@ impl IMMU for TestMMU {
         })
     }
 
-    fn translate_phys(&self, paddr: PhysAddr, len: usize) -> Result<&'static mut [u8], MMUError> {
-        unsafe {
-            self.alloc
-                .lock()
-                .linear_map(PhysAddrRange::from_start_len(paddr, len))
-                .ok_or(MMUError::AccessFault)
-        }
+    fn linear_map_phys(&self, paddr: PhysAddr, len: usize) -> Result<&'static mut [u8], MMUError> {
+        self.alloc
+            .lock()
+            .linear_map(PhysAddrRange::from_start_len(paddr, len))
+            .ok_or(MMUError::AccessFault)
     }
 
     fn platform_payload(&self) -> usize {

--- a/test-utilities/src/memory.rs
+++ b/test-utilities/src/memory.rs
@@ -277,10 +277,12 @@ impl IMMU for TestMMU {
     }
 
     fn linear_map_phys(&self, paddr: PhysAddr, len: usize) -> Result<&'static mut [u8], MMUError> {
-        self.alloc
-            .lock()
-            .linear_map(PhysAddrRange::from_start_len(paddr, len))
-            .ok_or(MMUError::AccessFault)
+        unsafe {
+            self.alloc
+                .lock()
+                .linear_map(PhysAddrRange::from_start_len(paddr, len))
+                .ok_or(MMUError::AccessFault)
+        }
     }
 
     fn platform_payload(&self) -> usize {


### PR DESCRIPTION
This pull request refactors and standardizes the interface for frame allocators and MMU creation across the kernel and test utilities. The main focus is on removing the custom `ITestFrameAllocator` trait, enhancing the `IFrameAllocator` trait with new methods, and updating all dependent code to use the improved abstractions. This results in a more consistent and extensible interface for memory management and MMU-related operations.

### Frame Allocator Trait Improvements
* Added two new methods to `IFrameAllocator`: `check_paddr` for verifying physical address ranges, and `linear_map` for obtaining mutable slices to physical memory. These methods replace the previously custom methods in `ITestFrameAllocator`.
* Implemented the new `check_paddr` and `linear_map` methods for both native and test frame allocators, ensuring correct address range checking and memory mapping behavior.

### Removal of Redundant Traits and Code
* Removed the custom `ITestFrameAllocator` trait and its implementations, consolidating all frame allocator logic under the improved `IFrameAllocator` trait.
* Updated all references and usages in test utilities to use the new methods from `IFrameAllocator` directly, eliminating unnecessary trait indirection.

### MMU and Kernel Abstraction Enhancements
* Added a new `create_mmu` method to the `IKernel` trait and implemented it for both the main kernel and test kernel, allowing for flexible MMU instantiation with a provided frame allocator.
* Updated kernel and test kernel code to use the new MMU creation interface and standardized MMU activation method signatures.

### Test MMU Logic Updates
* Refactored the test MMU implementation to use the new frame allocator interface for address checking and linear mapping, simplifying the logic for physical address translation and access fault handling.

### Miscellaneous
* Minor cleanup in dependencies and file imports to reflect the removal of unused traits and to align with the new abstractions.

This refactor improves code maintainability, extensibility, and consistency in memory management across kernel and test environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Kernel can create/provide an MMU instance and expose an optional bound allocator; allocators can validate physical-address ranges and optionally provide linear mappings.

- Refactor
  - Kernel allocator API renamed; MMU and mapping APIs updated to use range-based/linear-map terminology.

- Tests
  - Test utilities and TestMMU updated to use allocator-backed, range-based mappings.

- Chores
  - Removed libc dependency from test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->